### PR TITLE
feat(sim): add deterministic simulation loop

### DIFF
--- a/packages/sim/package.json
+++ b/packages/sim/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@aife/sim",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/sim/src/index.ts
+++ b/packages/sim/src/index.ts
@@ -1,0 +1,2 @@
+export type { Rng } from './rng';
+export { Simulation, type SimulationOptions } from './simulation';

--- a/packages/sim/src/rng.ts
+++ b/packages/sim/src/rng.ts
@@ -1,0 +1,31 @@
+/**
+ * Pseudorandom number generator producing deterministic sequences from a seed.
+ *
+ * This generator uses the Mulberry32 algorithm, which is fast and has a
+ * sufficiently long period for simulation purposes. The generated numbers are
+ * floating point values in the range [0, 1).
+ */
+export interface Rng {
+  /**
+   * Returns the next pseudo-random number in the range [0, 1).
+   */
+  next(): number;
+}
+
+/**
+ * Creates a new {@link Rng} seeded with the provided value.
+ *
+ * @param seed - Unsigned 32-bit integer used to seed the generator.
+ * @returns A deterministic random number generator.
+ */
+export function createRng(seed: number): Rng {
+  let state = seed >>> 0;
+  return {
+    next: (): number => {
+      state = (state + 0x6d2b79f5) | 0;
+      let t = Math.imul(state ^ (state >>> 15), 1 | state);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+  };
+}

--- a/packages/sim/src/simulation.ts
+++ b/packages/sim/src/simulation.ts
@@ -1,0 +1,101 @@
+import type { Rng } from './rng';
+import { createRng } from './rng';
+
+/**
+ * Options for constructing a {@link Simulation} instance.
+ *
+ * @typeParam State - Shape of the mutable simulation state object.
+ */
+export interface SimulationOptions<State> {
+  /**
+   * Fixed duration of a single simulation tick in milliseconds.
+   */
+  readonly timestepMs: number;
+  /**
+   * Seed used to initialize the internal random number generator.
+   */
+  readonly seed: number;
+  /**
+   * Initial state of the simulation. It will be mutated in place by the
+   * {@link update} function during each tick.
+   */
+  readonly initialState: State;
+  /**
+   * Function invoked on every tick of the simulation. It receives the current
+   * state, a deterministic random number generator and the fixed timestep in
+   * milliseconds.
+   */
+  readonly update: (state: State, rng: Rng, deltaMs: number) => void;
+}
+
+/**
+ * Runs a simulation loop with a fixed timestep and deterministic random number
+ * generator. The loop can be advanced manually or via {@link start} which
+ * schedules ticks using `setInterval`.
+ *
+ * @typeParam State - Shape of the mutable simulation state object.
+ */
+export class Simulation<State> {
+  private readonly timestepMs: number;
+  private readonly update: (state: State, rng: Rng, deltaMs: number) => void;
+  private readonly rng: Rng;
+  private readonly state: State;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private tickCount = 0;
+
+  constructor(options: SimulationOptions<State>) {
+    this.timestepMs = options.timestepMs;
+    this.update = options.update;
+    this.rng = createRng(options.seed);
+    this.state = options.initialState;
+  }
+
+  /**
+   * Begins automatically advancing the simulation at the configured timestep.
+   * Subsequent calls have no effect until {@link stop} is invoked.
+   */
+  start(): void {
+    if (this.timer !== null) {
+      return;
+    }
+    this.timer = setInterval(() => this.advance(), this.timestepMs);
+  }
+
+  /**
+   * Stops automatic advancement started by {@link start}.
+   */
+  stop(): void {
+    if (this.timer === null) {
+      return;
+    }
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /**
+   * Advances the simulation by a given number of ticks. Defaults to a single
+   * tick when no parameter is provided.
+   *
+   * @param steps - Number of fixed ticks to process.
+   */
+  advance(steps = 1): void {
+    for (let i = 0; i < steps; i++) {
+      this.update(this.state, this.rng, this.timestepMs);
+      this.tickCount += 1;
+    }
+  }
+
+  /**
+   * Current mutable simulation state.
+   */
+  get currentState(): State {
+    return this.state;
+  }
+
+  /**
+   * Number of ticks processed since the simulation was created.
+   */
+  get tick(): number {
+    return this.tickCount;
+  }
+}

--- a/packages/sim/test/simulation.test.ts
+++ b/packages/sim/test/simulation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Simulation } from '../src';
+
+describe('Simulation', () => {
+  it('produces identical state for identical seeds', () => {
+    const createSim = () =>
+      new Simulation<{ values: number[] }>({
+        timestepMs: 16,
+        seed: 123,
+        initialState: { values: [] },
+        update: (state, rng) => {
+          state.values.push(rng.next());
+        },
+      });
+
+    const simA = createSim();
+    const simB = createSim();
+
+    simA.advance(5);
+    simB.advance(5);
+
+    expect(simA.currentState).toEqual(simB.currentState);
+    expect(simA.tick).toBe(simB.tick);
+  });
+
+  it('stops advancing once stop is called', () => {
+    vi.useFakeTimers();
+
+    const sim = new Simulation<{ tick: number }>({
+      timestepMs: 10,
+      seed: 1,
+      initialState: { tick: 0 },
+      update: (state) => {
+        state.tick += 1;
+      },
+    });
+
+    sim.start();
+    vi.advanceTimersByTime(35); // advance ~3 ticks
+    sim.stop();
+
+    const ticksAfterStop = sim.tick;
+    vi.advanceTimersByTime(50);
+
+    expect(sim.tick).toBe(ticksAfterStop);
+  });
+});

--- a/packages/sim/tsconfig.json
+++ b/packages/sim/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node", "vitest"],
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,15 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.11)
 
+  packages/sim:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.11
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.11)
+
 packages:
 
   '@babel/runtime@7.28.3':


### PR DESCRIPTION
## Summary
- add `@aife/sim` package providing fixed-timestep simulation loop
- seedable RNG with mulberry32 algorithm for deterministic progression
- expose `start`, `stop`, and manual `advance` APIs
- tests cover reproducible state and timer-based stopping

## Testing
- `pnpm --filter @aife/sim test`
- `pnpm --filter @aife/sim typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3a4aeeb54832a92966a3d410b1d42