### PR TITLE
feat(tools): add asset pipeline placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
     "changeset": "changeset"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.29.6",
     "@biomejs/biome": "^2.2.0",
+    "@changesets/cli": "^2.29.6",
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "basisu": "^1.16.3",
+    "gltfpack": "^0.24.0",
     "turbo": "^2.5.6",
     "typescript": "^5.9.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.6
         version: 2.29.6(@types/node@20.19.11)
+      '@ffmpeg-installer/ffmpeg':
+        specifier: ^1.1.0
+        version: 1.1.0
+      basisu:
+        specifier: ^1.16.3
+        version: 1.16.3
+      gltfpack:
+        specifier: ^0.24.0
+        version: 0.24.0
       turbo:
         specifier: ^2.5.6
         version: 2.5.6
@@ -393,6 +402,49 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    resolution: {integrity: sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    resolution: {integrity: sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==}
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    resolution: {integrity: sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    resolution: {integrity: sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    resolution: {integrity: sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    resolution: {integrity: sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    resolution: {integrity: sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    resolution: {integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/external-editor@1.0.1':
     resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
     engines: {node: '>=18'}
@@ -590,6 +642,10 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  basisu@1.16.3:
+    resolution: {integrity: sha512-lrUCNmZDAaO1I4TUNqEHLx5fb+9tiOZxaVpVorO4FZbg4DiUCsDZS3rWy7uyFwGdYev5d8l3TKAHUIyheBhcUw==}
+    hasBin: true
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -600,6 +656,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buildcheck@0.0.3:
+    resolution: {integrity: sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==}
+    engines: {node: '>=10.0.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -621,6 +681,10 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  cpu-features@0.0.4:
+    resolution: {integrity: sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==}
+    engines: {node: '>=10.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -690,6 +754,10 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -717,6 +785,11 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  gltfpack@0.24.0:
+    resolution: {integrity: sha512-IV+ykiSebCqsSsHM65vZZV2TSWPGNudn9a07dPLYUJ1wmBattF1vNIdZzgAuwfZEPKhg2mQFsIJAXANYfYM50w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -774,6 +847,9 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
@@ -815,6 +891,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.23.0:
+    resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1074,6 +1153,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -1454,6 +1537,41 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    optional: true
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    optionalDependencies:
+      '@ffmpeg-installer/darwin-arm64': 4.1.5
+      '@ffmpeg-installer/darwin-x64': 4.1.0
+      '@ffmpeg-installer/linux-arm': 4.1.3
+      '@ffmpeg-installer/linux-arm64': 4.1.4
+      '@ffmpeg-installer/linux-ia32': 4.1.0
+      '@ffmpeg-installer/linux-x64': 4.1.0
+      '@ffmpeg-installer/win32-ia32': 4.1.0
+      '@ffmpeg-installer/win32-x64': 4.1.0
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    optional: true
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    optional: true
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    optional: true
+
   '@inquirer/external-editor@1.0.1(@types/node@20.19.11)':
     dependencies:
       chardet: 2.1.0
@@ -1621,6 +1739,11 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  basisu@1.16.3:
+    dependencies:
+      cpu-features: 0.0.4
+      fs-extra: 11.3.1
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -1630,6 +1753,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buildcheck@0.0.3: {}
 
   cac@6.7.14: {}
 
@@ -1652,6 +1777,11 @@ snapshots:
   ci-info@3.9.0: {}
 
   confbox@0.1.8: {}
+
+  cpu-features@0.0.4:
+    dependencies:
+      buildcheck: 0.0.3
+      nan: 2.23.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1747,6 +1877,12 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fs-extra@11.3.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -1778,6 +1914,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  gltfpack@0.24.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -1817,6 +1955,12 @@ snapshots:
       esprima: 4.0.1
 
   jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
 
@@ -1860,6 +2004,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  nan@2.23.0: {}
 
   nanoid@3.3.11: {}
 
@@ -2075,6 +2221,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   vite-node@1.6.1(@types/node@20.19.11):
     dependencies:

--- a/tools/basisu/README.md
+++ b/tools/basisu/README.md
@@ -1,0 +1,19 @@
+# basisu Tool
+
+Placeholder wrapper for the [`basisu`](https://github.com/BinomialLLC/basis_universal) CLI.
+
+## Usage
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+Run the script, forwarding any arguments supported by `basisu`:
+
+```sh
+pnpm dlx tsx tools/basisu/index.ts -- [basisu arguments]
+```
+
+The script invokes `pnpm exec basisu` internally.

--- a/tools/basisu/index.ts
+++ b/tools/basisu/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runTool } from '../run-tool.js';
+
+/**
+ * Proxy for the `basisu` CLI installed via pnpm.
+ */
+runTool('basisu');

--- a/tools/ffmpeg/README.md
+++ b/tools/ffmpeg/README.md
@@ -1,0 +1,19 @@
+# ffmpeg Tool
+
+Placeholder wrapper for the [`ffmpeg`](https://ffmpeg.org/) CLI.
+
+## Usage
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+Run the script, forwarding any arguments supported by `ffmpeg`:
+
+```sh
+pnpm dlx tsx tools/ffmpeg/index.ts -- [ffmpeg arguments]
+```
+
+The script invokes `pnpm exec ffmpeg` internally.

--- a/tools/ffmpeg/index.ts
+++ b/tools/ffmpeg/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runTool } from '../run-tool.js';
+
+/**
+ * Proxy for the `ffmpeg` CLI installed via pnpm.
+ */
+runTool('ffmpeg');

--- a/tools/gltfpack/README.md
+++ b/tools/gltfpack/README.md
@@ -1,0 +1,19 @@
+# gltfpack Tool
+
+Placeholder wrapper for the [`gltfpack`](https://github.com/zeux/meshoptimizer/tree/master/gltf) CLI.
+
+## Usage
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+Run the script, forwarding any arguments supported by `gltfpack`:
+
+```sh
+pnpm dlx tsx tools/gltfpack/index.ts -- [gltfpack arguments]
+```
+
+The script invokes `pnpm exec gltfpack` internally.

--- a/tools/gltfpack/index.ts
+++ b/tools/gltfpack/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runTool } from '../run-tool.js';
+
+/**
+ * Proxy for the `gltfpack` CLI installed via pnpm.
+ */
+runTool('gltfpack');

--- a/tools/run-tool.ts
+++ b/tools/run-tool.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Executes a pnpm-managed CLI and forwards all process arguments.
+ *
+ * @param toolName - CLI binary name to invoke via `pnpm exec`.
+ */
+export function runTool(toolName: string): void {
+  const result = spawnSync('pnpm', ['exec', toolName, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(`Failed to run ${toolName}:`, result.error);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 0);
+}


### PR DESCRIPTION
## Summary
- scaffold placeholder wrappers for gltfpack, basisu and ffmpeg
- document usage for each asset pipeline tool
- add required CLI dependencies

## Testing
- `pnpm lint tools`
- `pnpm test tools` *(fails: Could not find task `tools` in project)*
- `pnpm typecheck tools` *(fails: Could not find task `tools` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a8ec1c5c832ab43bfd38fe542728