### PR TITLE
docs: add README and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Didier Monorepo
+
+This repository contains the game client, server, shared packages, and tools managed in a pnpm/Turborepo workspace.
+
+## Install
+
+```bash
+pnpm install
+```
+
+## Development
+
+```bash
+pnpm dev
+```
+
+## Test
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+## Build
+
+```bash
+pnpm build
+```
+
+## Protocol
+
+The network protocol is version **0.1.0** and lives in [`packages/protocol`](packages/protocol). See [docs/protocol.md](docs/protocol.md) for regeneration commands and compatibility notes.
+
+## Architecture
+
+Architecture diagrams for the monorepo and runtime are available in [docs/architecture.md](docs/architecture.md).

--- a/docs/adr/0001-pnpm-turborepo-monorepo.md
+++ b/docs/adr/0001-pnpm-turborepo-monorepo.md
@@ -1,0 +1,10 @@
+# ADR 0001: Use pnpm with Turborepo for Monorepo
+- Date: 2025-02-14
+- pnpm installs are deterministic and space-efficient.
+- Turborepo provides incremental task execution and caching.
+- Shared toolchain simplifies developer experience.
+- Alternatives (npm, yarn, lerna) lacked native caching.
+- Decision centralizes scripts across apps and packages.
+- Remote cache keeps CI builds fast.
+- Outcome: adopt pnpm + Turborepo for long-term monorepo management.
+- Status: accepted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,38 @@
+# Architecture
+
+## Monorepo Overview
+
+```mermaid
+graph TD
+    subgraph Apps
+        AC[apps/client]
+        AS[apps/server]
+    end
+    subgraph Packages
+        P[@aife/protocol]
+        E[@aife/ecs]
+        S[@aife/sim]
+        N[@aife/netcode]
+        U[@aife/ui]
+    end
+    AC --> P
+    AS --> P
+    AC --> N
+    AS --> N
+    N --> S
+    S --> E
+    AC --> U
+```
+
+## Runtime Overview
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server
+    participant DB as PostgreSQL
+    participant R as Redis
+    C->>S: Colyseus WebSocket
+    S->>DB: Queries via Prisma
+    S->>R: Matchmaking & Sessions
+```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,6 @@
+# Protocol
+
+- Current version: 0.1.0
+- Schemas live in `packages/protocol` and are generated from Protobuf definitions.
+- Regenerate code with `pnpm --filter @aife/protocol generate`.
+- Changes must remain backward compatible.


### PR DESCRIPTION
## Summary
- document install, dev, test, build workflows in new README
- add ADR on pnpm/Turborepo monorepo
- document protocol version and provide architecture diagrams

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: ../../node_modules/.pnpm/@types+node@20.19.11/node_modules/@types/node/https.d.ts(310,65): error TS1005: ')' expected.)*
- `pnpm test` *(fails: @aife/protocol:build: ../../node_modules/.pnpm/@types+node@20.19.11/node_modules/@types/node/https.d.ts(310,92): error TS1005: '(' expected.)*
- `pnpm build` *(fails: @aife/protocol:build: ../../node_modules/.pnpm/@types+node@20.19.11/node_modules/@types/node/https.d.ts(310,65): error TS1005: ')' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4252aa190832abc53a8f5d2c62d9a