### PR TITLE
feat(netcode): add core primitives

### DIFF
--- a/packages/netcode/package.json
+++ b/packages/netcode/package.json
@@ -12,7 +12,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
+    "@types/ws": "^8.5.10",
     "vitest": "^1.6.0",
-    "ws": "^8.17.0"
+    "ws": "^8.17.0",
+    "fflate": "^0.8.2"
   }
 }

--- a/packages/netcode/src/clock-sync.ts
+++ b/packages/netcode/src/clock-sync.ts
@@ -1,0 +1,64 @@
+/**
+ * Maintains a smoothed estimate of network latency and clock offset.
+ *
+ * The algorithm uses an exponential moving average (EMA) over round trip time
+ * (RTT) samples. Each sample is produced from a ping where the client records
+ * the send and receive times and the server echoes its current time. The
+ * offset represents the difference between the server and client clocks such
+ * that `serverTime ≈ clientTime + offset`.
+ */
+export class ClockSync {
+  private readonly smoothing: number;
+  private pingEstimate: number | undefined;
+  private offsetEstimate: number | undefined;
+
+  /**
+   * @param smoothing - Smoothing factor for the exponential moving average in
+   * the open interval (0,1]. A higher value reacts faster to changes.
+   */
+  constructor(smoothing = 0.1) {
+    if (smoothing <= 0 || smoothing > 1) {
+      throw new RangeError('smoothing must be in (0,1]');
+    }
+    this.smoothing = smoothing;
+  }
+
+  /**
+    * Incorporates a new ping sample.
+    *
+    * @param clientSent - Client timestamp when the ping was sent.
+    * @param serverTime - Server timestamp echoed back with the pong.
+    * @param clientReceived - Client timestamp when the pong was received.
+    */
+  sample(clientSent: number, serverTime: number, clientReceived: number): void {
+    if (clientReceived < clientSent) {
+      throw new RangeError('clientReceived must be >= clientSent');
+    }
+    const rtt = clientReceived - clientSent;
+    const offset = serverTime - (clientSent + rtt / 2);
+
+    this.pingEstimate = this.exponentialAverage(this.pingEstimate, rtt);
+    this.offsetEstimate = this.exponentialAverage(this.offsetEstimate, offset);
+  }
+
+  /** Returns the current ping estimate in milliseconds. */
+  get ping(): number {
+    return this.pingEstimate ?? 0;
+  }
+
+  /** Returns the current clock offset estimate in milliseconds. */
+  get offset(): number {
+    return this.offsetEstimate ?? 0;
+  }
+
+  private exponentialAverage(
+    previous: number | undefined,
+    sample: number,
+  ): number {
+    if (previous === undefined) {
+      return sample;
+    }
+    return previous + this.smoothing * (sample - previous);
+  }
+}
+

--- a/packages/netcode/src/index.ts
+++ b/packages/netcode/src/index.ts
@@ -2,3 +2,6 @@ export * from './input-buffer';
 export * from './interpolation';
 export * from './reconciliation';
 export * from './codec';
+export * from './clock-sync';
+export * from './snapshot-buffer';
+export * from './packets';

--- a/packages/netcode/src/packets.ts
+++ b/packages/netcode/src/packets.ts
@@ -1,0 +1,88 @@
+import {
+  Ack,
+  Input,
+  ServerTime,
+  Snapshot,
+} from '@aife/protocol';
+
+/** Identifiers for the supported packet types. */
+export enum PacketKind {
+  Input = 1,
+  Snapshot = 2,
+  Ack = 3,
+  ServerTime = 4,
+}
+
+type PacketMap = {
+  [PacketKind.Input]: Input;
+  [PacketKind.Snapshot]: Snapshot;
+  [PacketKind.Ack]: Ack;
+  [PacketKind.ServerTime]: ServerTime;
+};
+
+/** Union of all packet variants. */
+export type Packet = {
+  [K in PacketKind]: { kind: K; message: PacketMap[K] };
+}[PacketKind];
+
+/** Optional compression helpers. */
+export interface Compression {
+  compress(data: Uint8Array): Uint8Array;
+  decompress(data: Uint8Array): Uint8Array;
+}
+
+const encoders: { [K in PacketKind]: (m: PacketMap[K]) => Uint8Array } = {
+  [PacketKind.Input]: (m) => m.toBinary(),
+  [PacketKind.Snapshot]: (m) => m.toBinary(),
+  [PacketKind.Ack]: (m) => m.toBinary(),
+  [PacketKind.ServerTime]: (m) => m.toBinary(),
+};
+
+const decoders: { [K in PacketKind]: (b: Uint8Array) => PacketMap[K] } = {
+  [PacketKind.Input]: (b) => Input.fromBinary(b),
+  [PacketKind.Snapshot]: (b) => Snapshot.fromBinary(b),
+  [PacketKind.Ack]: (b) => Ack.fromBinary(b),
+  [PacketKind.ServerTime]: (b) => ServerTime.fromBinary(b),
+};
+
+/**
+ * Encodes a packet with a simple header.
+ *
+ * Header layout:
+ * - byte 0: packet kind
+ * - byte 1: compression flag (0 = none, 1 = compressed)
+ */
+export const encodePacket = (
+  packet: Packet,
+  compression?: Compression,
+): Uint8Array => {
+  const payload = encoders[packet.kind](packet.message as never);
+  const body = compression ? compression.compress(payload) : payload;
+  const bytes = new Uint8Array(2 + body.length);
+  bytes[0] = packet.kind;
+  bytes[1] = compression ? 1 : 0;
+  bytes.set(body, 2);
+  return bytes;
+};
+
+/** Decodes a packet previously encoded with {@link encodePacket}. */
+export const decodePacket = (
+  data: Uint8Array,
+  compression?: Compression,
+): Packet => {
+  if (data.length < 2) {
+    throw new Error('Packet too short');
+  }
+  const kind = data[0] as PacketKind;
+  const isCompressed = data[1] === 1;
+  const body = data.slice(2);
+  const payload = isCompressed
+    ? compression?.decompress(body) ??
+      (() => {
+        throw new Error('Compressed packet but no decompressor provided');
+      })()
+    : body;
+  const message = decoders[kind](payload);
+  return { kind, message } as Packet;
+};
+

--- a/packages/netcode/src/snapshot-buffer.ts
+++ b/packages/netcode/src/snapshot-buffer.ts
@@ -1,0 +1,71 @@
+/**
+ * Ring buffer storing timestamped snapshots.
+ *
+ * Snapshots are inserted in chronological order and the buffer keeps only the
+ * most recent entries up to its fixed capacity. It is primarily used on the
+ * client to interpolate between snapshots received from the server.
+ */
+export interface TimestampedSnapshot<T> {
+  /** Timestamp in milliseconds of the snapshot. */
+  readonly timestamp: number;
+  /** Snapshot data. */
+  readonly snapshot: T;
+}
+
+export class SnapshotBuffer<T> {
+  private readonly buffer: Array<TimestampedSnapshot<T> | undefined>;
+  private next = 0;
+  private count = 0;
+
+  constructor(private readonly capacity: number) {
+    if (capacity <= 0) {
+      throw new RangeError('capacity must be positive');
+    }
+    this.buffer = new Array(capacity);
+  }
+
+  /** Inserts a snapshot at the given timestamp. */
+  push(timestamp: number, snapshot: T): void {
+    this.buffer[this.next] = { timestamp, snapshot };
+    this.next = (this.next + 1) % this.capacity;
+    this.count = Math.min(this.count + 1, this.capacity);
+  }
+
+  /** Returns the latest snapshot or undefined if the buffer is empty. */
+  latest(): TimestampedSnapshot<T> | undefined {
+    if (this.count === 0) {
+      return undefined;
+    }
+    const index = (this.next - 1 + this.capacity) % this.capacity;
+    return this.buffer[index];
+  }
+
+  /**
+   * Finds the two snapshots surrounding the given timestamp for interpolation.
+   *
+   * @returns A tuple [previous, next] or undefined if not enough data or the
+   * target is out of range.
+   */
+  pairAround(
+    timestamp: number,
+  ): readonly [TimestampedSnapshot<T>, TimestampedSnapshot<T>] | undefined {
+    if (this.count < 2) {
+      return undefined;
+    }
+    const first = (this.next - this.count + this.capacity) % this.capacity;
+    let prev = this.buffer[first]!;
+    if (timestamp < prev.timestamp) {
+      return undefined;
+    }
+    for (let i = 1; i < this.count; i++) {
+      const idx = (first + i) % this.capacity;
+      const curr = this.buffer[idx]!;
+      if (timestamp < curr.timestamp) {
+        return [prev, curr];
+      }
+      prev = curr;
+    }
+    return undefined;
+  }
+}
+

--- a/packages/netcode/test/clock-sync.test.ts
+++ b/packages/netcode/test/clock-sync.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ClockSync } from '../src';
+
+describe('ClockSync', () => {
+  it('smooths ping and offset under jitter', () => {
+    const sync = new ClockSync(0.5);
+    const serverAhead = 40; // ms
+    const rtts = [100, 120, 80, 110, 90];
+    let clientTime = 1000;
+    for (const rtt of rtts) {
+      const sent = clientTime;
+      const serverTime = clientTime + serverAhead + rtt / 2;
+      const received = clientTime + rtt;
+      sync.sample(sent, serverTime, received);
+      clientTime += 100;
+    }
+    expect(Math.abs(sync.ping - 100)).toBeLessThan(10);
+    expect(Math.abs(sync.offset - serverAhead)).toBeLessThan(10);
+  });
+});
+

--- a/packages/netcode/test/packets.test.ts
+++ b/packages/netcode/test/packets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { Ack, Input, ServerTime, Snapshot } from '@aife/protocol';
+import { PacketKind, decodePacket, encodePacket } from '../src';
+import { deflateSync, inflateSync } from 'fflate';
+
+const compression = {
+  compress: (d: Uint8Array) => deflateSync(d),
+  decompress: (d: Uint8Array) => inflateSync(d),
+};
+
+describe('packets', () => {
+  it('encodes and decodes snapshot packets with compression', () => {
+    const packet = {
+      kind: PacketKind.Snapshot as const,
+      message: new Snapshot({ version: 1, positions: [1, 2] }),
+    };
+    const encoded = encodePacket(packet, compression);
+    const decoded = decodePacket(encoded, compression);
+    if (decoded.kind !== PacketKind.Snapshot) {
+      throw new Error('expected snapshot');
+    }
+    expect(decoded.message.positions).toEqual([1, 2]);
+  });
+
+  it('encodes and decodes input packets without compression', () => {
+    const packet = {
+      kind: PacketKind.Input as const,
+      message: new Input({ version: 1, horizontal: 1, vertical: -1 }),
+    };
+    const encoded = encodePacket(packet);
+    const decoded = decodePacket(encoded);
+    if (decoded.kind !== PacketKind.Input) {
+      throw new Error('expected input');
+    }
+    expect(decoded.message.horizontal).toBe(1);
+    expect(decoded.message.vertical).toBe(-1);
+  });
+
+  it('throws when decoding compressed packet without decompressor', () => {
+    const packet = {
+      kind: PacketKind.Ack as const,
+      message: new Ack({ version: 1, inputTick: 5 }),
+    };
+    const encoded = encodePacket(packet, compression);
+    expect(() => decodePacket(encoded)).toThrow();
+  });
+
+  it('handles server time packets', () => {
+    const now = Date.now();
+    const packet = {
+      kind: PacketKind.ServerTime as const,
+      message: new ServerTime({ version: 1, unixMilliseconds: BigInt(now) }),
+    };
+    const encoded = encodePacket(packet);
+    const decoded = decodePacket(encoded);
+    if (decoded.kind !== PacketKind.ServerTime) {
+      throw new Error('expected server time');
+    }
+    expect(Number(decoded.message.unixMilliseconds)).toBe(now);
+  });
+});
+

--- a/packages/netcode/test/snapshot-buffer.test.ts
+++ b/packages/netcode/test/snapshot-buffer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { SnapshotBuffer } from '../src';
+
+describe('SnapshotBuffer', () => {
+  it('provides interpolation pairs despite jitter', () => {
+    const buffer = new SnapshotBuffer<number>(5);
+    buffer.push(0, 0);
+    buffer.push(110, 1);
+    buffer.push(230, 2);
+    buffer.push(360, 3);
+    const pair = buffer.pairAround(250);
+    expect(pair?.[0].snapshot).toBe(2);
+    expect(pair?.[1].snapshot).toBe(3);
+  });
+
+  it('drops old snapshots when capacity is exceeded', () => {
+    const buffer = new SnapshotBuffer<number>(3);
+    buffer.push(0, 0);
+    buffer.push(100, 1);
+    buffer.push(200, 2);
+    buffer.push(300, 3);
+    expect(buffer.pairAround(50)).toBeUndefined();
+    expect(buffer.latest()?.snapshot).toBe(3);
+  });
+});
+

--- a/packages/netcode/test/snapshot-flow.integration.test.ts
+++ b/packages/netcode/test/snapshot-flow.integration.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { WebSocketServer, WebSocket } from 'ws';
+import {
+  WebSocketServer,
+  WebSocket,
+  MessageEvent,
+  ErrorEvent,
+} from 'ws';
 import { Snapshot } from '@aife/protocol';
 import { encodeSnapshot, decodeSnapshot } from '../src/codec';
 
@@ -14,15 +19,15 @@ describe('snapshot flow', () => {
     await new Promise<void>((resolve, reject) => {
       const client = new WebSocket('ws://localhost:12350');
       client.binaryType = 'arraybuffer';
-      client.onmessage = (event) => {
+      client.onmessage = (event: MessageEvent) => {
         const received = decodeSnapshot(new Uint8Array(event.data as ArrayBuffer));
         expect(received.positions).toEqual(snapshot.positions);
         expect(received.version).toBe(snapshot.version);
         client.close();
         resolve();
       };
-      client.onerror = (err) => {
-        reject(err);
+      client.onerror = (event: ErrorEvent) => {
+        reject(event.error as Error);
       };
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,12 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.11
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.11)(jsdom@26.1.0)


### PR DESCRIPTION
## Summary
- implement clock-based latency and offset estimation
- add timestamped snapshot ring buffer
- provide packet header helpers with optional compression

## Testing
- `pnpm --filter @aife/netcode typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44ea6f6f8832aa669e223cabaf86d