### PR TITLE
feat(ecs): add core components and reusable queries

### DIFF
--- a/packages/ecs/src/components.ts
+++ b/packages/ecs/src/components.ts
@@ -15,3 +15,31 @@ export const Velocity = defineComponent({
   x: Types.f32,
   y: Types.f32,
 });
+
+/**
+ * Health of an entity represented by its current and maximum values.
+ */
+export const Health = defineComponent({
+  current: Types.f32,
+  max: Types.f32,
+});
+
+/**
+ * Current input state for an entity.
+ *
+ * Each field is treated as a boolean flag (1 = pressed, 0 = released).
+ */
+export const InputState = defineComponent({
+  up: Types.ui8,
+  down: Types.ui8,
+  left: Types.ui8,
+  right: Types.ui8,
+  action: Types.ui8,
+});
+
+/**
+ * Team identifier for grouping entities.
+ */
+export const Team = defineComponent({
+  id: Types.ui8,
+});

--- a/packages/ecs/src/index.ts
+++ b/packages/ecs/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './components';
 export * from './factories';
+export * from './queries';
 export * from './systems/movement';

--- a/packages/ecs/src/queries.ts
+++ b/packages/ecs/src/queries.ts
@@ -1,0 +1,22 @@
+import { defineQuery } from 'bitecs';
+import { Health, InputState, Position, Team, Velocity } from './components';
+
+/**
+ * Entities that possess both {@link Position} and {@link Velocity} components.
+ */
+export const movableQuery = defineQuery([Position, Velocity]);
+
+/**
+ * Entities that expose a {@link Health} component.
+ */
+export const healthQuery = defineQuery([Health]);
+
+/**
+ * Entities providing an {@link InputState} component.
+ */
+export const inputQuery = defineQuery([InputState]);
+
+/**
+ * Entities associated with a {@link Team} identifier.
+ */
+export const teamQuery = defineQuery([Team]);

--- a/packages/ecs/src/systems/movement.ts
+++ b/packages/ecs/src/systems/movement.ts
@@ -1,8 +1,6 @@
-import { defineQuery } from 'bitecs';
 import type { IWorld } from 'bitecs';
 import { Position, Velocity } from '../components';
-
-const movableQuery = defineQuery([Position, Velocity]);
+import { movableQuery } from '../queries';
 
 /**
  * Advances entity positions by applying velocity.

--- a/packages/ecs/test/queries.test.ts
+++ b/packages/ecs/test/queries.test.ts
@@ -1,0 +1,118 @@
+import {
+  addComponent,
+  addEntity,
+  createWorld,
+  resetGlobals,
+  type IWorld,
+} from 'bitecs';
+import { describe, expect, it } from 'vitest';
+import {
+  Health,
+  InputState,
+  Position,
+  Team,
+  Velocity,
+  healthQuery,
+  inputQuery,
+  movableQuery,
+  teamQuery,
+} from '../src';
+
+/**
+ * Linear congruential generator producing deterministic sequences.
+ */
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+interface SeededWorld {
+  world: IWorld;
+  movable: number[];
+  withHealth: number[];
+  withInput: number[];
+  withTeam: number[];
+}
+
+function buildSeededWorld(seed: number, count: number): SeededWorld {
+  const rand = makeRng(seed);
+  const world = createWorld();
+  const movable: number[] = [];
+  const withHealth: number[] = [];
+  const withInput: number[] = [];
+  const withTeam: number[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const eid = addEntity(world);
+    const hasPosition = rand() > 0.5;
+    const hasVelocity = rand() > 0.5;
+    if (hasPosition) {
+      addComponent(world, Position, eid);
+      Position.x[eid] = rand();
+      Position.y[eid] = rand();
+    }
+    if (hasVelocity) {
+      addComponent(world, Velocity, eid);
+      Velocity.x[eid] = rand();
+      Velocity.y[eid] = rand();
+    }
+    if (hasPosition && hasVelocity) {
+      movable.push(eid);
+    }
+    if (rand() > 0.5) {
+      addComponent(world, Health, eid);
+      Health.current[eid] = rand() * 100;
+      Health.max[eid] = 100;
+      withHealth.push(eid);
+    }
+    if (rand() > 0.5) {
+      addComponent(world, InputState, eid);
+      InputState.up[eid] = rand() > 0.5 ? 1 : 0;
+      InputState.down[eid] = rand() > 0.5 ? 1 : 0;
+      InputState.left[eid] = rand() > 0.5 ? 1 : 0;
+      InputState.right[eid] = rand() > 0.5 ? 1 : 0;
+      InputState.action[eid] = rand() > 0.5 ? 1 : 0;
+      withInput.push(eid);
+    }
+    if (rand() > 0.5) {
+      addComponent(world, Team, eid);
+      Team.id[eid] = Math.floor(rand() * 4);
+      withTeam.push(eid);
+    }
+  }
+
+  return { world, movable, withHealth, withInput, withTeam };
+}
+
+describe('reusable queries', () => {
+  it('Given identical seeds When building worlds Then queries select identical entities', () => {
+    const worldA = buildSeededWorld(123, 20);
+    resetGlobals();
+    const worldB = buildSeededWorld(123, 20);
+
+    expect(Array.from(movableQuery(worldA.world))).toEqual(
+      Array.from(movableQuery(worldB.world)),
+    );
+    expect(Array.from(healthQuery(worldA.world))).toEqual(
+      Array.from(healthQuery(worldB.world)),
+    );
+    expect(Array.from(inputQuery(worldA.world))).toEqual(
+      Array.from(inputQuery(worldB.world)),
+    );
+    expect(Array.from(teamQuery(worldA.world))).toEqual(
+      Array.from(teamQuery(worldB.world)),
+    );
+  });
+
+  it('Given a seeded world When running queries Then only entities with matching components are returned', () => {
+    const seeded = buildSeededWorld(42, 25);
+
+    expect(Array.from(movableQuery(seeded.world))).toEqual(seeded.movable);
+    expect(Array.from(healthQuery(seeded.world))).toEqual(seeded.withHealth);
+    expect(Array.from(inputQuery(seeded.world))).toEqual(seeded.withInput);
+    expect(Array.from(teamQuery(seeded.world))).toEqual(seeded.withTeam);
+  });
+});


### PR DESCRIPTION
## Summary
- add Health, InputState and Team components
- expose reusable queries for ECS systems
- cover query behavior with deterministic seeded tests

## Testing
- `pnpm exec biome lint packages/ecs/src packages/ecs/test`
- `pnpm --filter @aife/ecs typecheck`
- `pnpm test packages/ecs/test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4537a50832a97012675a5b01192