### PR TITLE
docs: add architecture decision records

### DIFF
--- a/docs/adr/0002-adopt_biome_for_code_style.md
+++ b/docs/adr/0002-adopt_biome_for_code_style.md
@@ -1,0 +1,10 @@
+# ADR 0002: Replace ESLint and Prettier with Biome
+- Date: 2025-08-18
+- Biome unifies formatting and linting in one tool.
+- Single config reduces dependency overhead.
+- Alternatives (ESLint+Prettier) duplicated responsibilities.
+- Biome's speed improves developer feedback loop.
+- Decision sets Biome as default code style guardian.
+- Consistency enforced across apps and packages.
+- Outcome: adopt Biome for linting, formatting, and imports.
+- Status: accepted.

--- a/docs/adr/0003-adopt_bitecs_for_ecs.md
+++ b/docs/adr/0003-adopt_bitecs_for_ecs.md
@@ -1,0 +1,10 @@
+# ADR 0003: Adopt Bitecs for Entity Component System
+- Date: 2025-08-19
+- Bitecs offers high-performance, memory-friendly ECS.
+- Deterministic, pure systems align with simulation goals.
+- Alternatives (ECSY, custom) added complexity.
+- Decision standardizes bitecs usage across packages.
+- Shared schemas ease client/server communication.
+- Strict typing enforces component boundaries.
+- Outcome: bitecs underpins all gameplay logic.
+- Status: accepted.

--- a/docs/adr/0004-fixed_timestep_deterministic_simulation.md
+++ b/docs/adr/0004-fixed_timestep_deterministic_simulation.md
@@ -1,0 +1,10 @@
+# ADR 0004: Implement Fixed Timestep Deterministic Simulation
+- Date: 2025-08-19
+- Fixed timestep ensures deterministic state progression.
+- Seeded RNG enables reproducible runs.
+- Clear separation between simulation and rendering.
+- Alternatives (variable timestep) caused desync.
+- Decision locks simulation to 60 Hz tick.
+- Server authoritative, client predicts locally.
+- Outcome: reliable replay and debugging.
+- Status: accepted.

--- a/docs/adr/0005-input_buffering_and_client_reconciliation.md
+++ b/docs/adr/0005-input_buffering_and_client_reconciliation.md
@@ -1,0 +1,10 @@
+# ADR 0005: Use Input Buffering with Client-Side Reconciliation
+- Date: 2025-08-19
+- Client buffers inputs while awaiting server ticks.
+- Server replies include authoritative state hashes.
+- Interpolation handles late packets.
+- Alternatives (no buffering) produced jitter and loss.
+- Decision keeps 64-tick history for rewinds.
+- Prediction uses previous state and pending inputs.
+- Outcome: smooth gameplay despite network latency.
+- Status: accepted.

--- a/docs/adr/0006-scaffold_asset_pipeline_cli.md
+++ b/docs/adr/0006-scaffold_asset_pipeline_cli.md
@@ -1,0 +1,10 @@
+# ADR 0006: Scaffold Asset Pipeline Command-Line Tools
+- Date: 2025-08-19
+- Centralized CLI handles model and audio processing.
+- Placeholders reserve targets for gltfpack, basisu, ffmpeg.
+- Reduces manual errors and ensures deterministic outputs.
+- Alternatives (manual scripts) risked inconsistency.
+- Decision standardizes asset optimization workflows.
+- Future extensions can plug into shared pipeline.
+- Outcome: prepared tooling for automated asset builds.
+- Status: accepted.

--- a/docs/adr/0007-use_fastify_with_colyseus_for_backend.md
+++ b/docs/adr/0007-use_fastify_with_colyseus_for_backend.md
@@ -1,0 +1,10 @@
+# ADR 0007: Use Fastify with Colyseus for Backend Server
+- Date: 2025-08-19
+- Fastify provides lightweight HTTP server and plugins.
+- Colyseus handles real-time room state sync.
+- Server remains authoritative over simulation state.
+- Alternatives (Express, custom WS) lacked performance or features.
+- Decision wires Fastify for health endpoints and Colyseus rooms.
+- Shared transport simplifies deployment and observability.
+- Outcome: unified backend serving REST and WebSockets.
+- Status: accepted.

--- a/docs/adr/0008-nextjs_pwa_with_react_three_fiber.md
+++ b/docs/adr/0008-nextjs_pwa_with_react_three_fiber.md
@@ -1,0 +1,10 @@
+# ADR 0008: Build Client with Next.js PWA and React Three Fiber
+- Date: 2025-08-19
+- Next.js app router enables streaming React components.
+- PWA shell allows offline caching and installability.
+- React Three Fiber manages WebGL scenes declaratively.
+- Alternatives (CRA, Vite) lacked integrated PWA support.
+- Decision couples Next.js pages with R3F canvas.
+- Shared UI components live in packages/ui.
+- Outcome: responsive client foundation for 3D gameplay.
+- Status: accepted.

--- a/docs/adr/0009-standardize_testing_with_vitest_and_playwright.md
+++ b/docs/adr/0009-standardize_testing_with_vitest_and_playwright.md
@@ -1,0 +1,10 @@
+# ADR 0009: Standardize Testing with Vitest and Playwright
+- Date: 2025-08-19
+- Vitest offers fast TypeScript-aware unit tests.
+- Playwright covers end-to-end browser scenarios.
+- Mock-friendly APIs aid deterministic simulations.
+- Alternatives (Jest, Cypress) added heavier runtimes.
+- Decision unifies test configs across packages and apps.
+- Coverage thresholds enforce code quality.
+- Outcome: reliable automated tests from unit to E2E.
+- Status: accepted.

--- a/docs/adr/0010-define_network_protocol_with_protobuf.md
+++ b/docs/adr/0010-define_network_protocol_with_protobuf.md
@@ -1,0 +1,10 @@
+# ADR 0010: Define Network Protocol with Protobuf Schemas
+- Date: 2025-08-19
+- Protobuf ensures compact, typed messages.
+- Buf tooling streamlines schema evolution.
+- Code generation syncs client and server contracts.
+- Alternatives (JSON, custom binary) were verbose or error-prone.
+- Decision stores .proto files in packages/protocol.
+- Golden files verify backward compatibility.
+- Outcome: stable cross-language network protocol.
+- Status: accepted.


### PR DESCRIPTION
## Summary
- document code style with Biome
- capture ECS, simulation, netcode, and asset pipeline decisions
- record server, client, testing, and protocol choices

## Testing
- `pnpm lint docs/adr` *(fails: unexpected any, useImportType, noNonNullAssertion)*
- `pnpm biome lint docs/adr`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5d4d918832a8095fd3a9feacfb9