### PR TITLE
feat(sim): deterministic engine with snapshots

### DIFF
--- a/packages/sim/src/index.ts
+++ b/packages/sim/src/index.ts
@@ -1,2 +1,15 @@
 export type { Rng } from './rng';
-export { Simulation, type SimulationOptions } from './simulation';
+export { createRng, createRngFromState } from './rng';
+export {
+  Simulation,
+  deserializeSimulation,
+  type SeededSimulationOptions,
+  type SnapshotSimulationOptions,
+  type SimulationOptions,
+} from './simulation';
+export {
+  deserializeSnapshot,
+  serializeSnapshot,
+  type SimulationSnapshot,
+} from './snapshot';
+export { runScenario } from './run-scenario';

--- a/packages/sim/src/rng.ts
+++ b/packages/sim/src/rng.ts
@@ -10,6 +10,12 @@ export interface Rng {
    * Returns the next pseudo-random number in the range [0, 1).
    */
   next(): number;
+
+  /**
+   * Current internal state of the generator. Exposing the state allows
+   * serialization and deterministic replay.
+   */
+  getState(): number;
 }
 
 /**
@@ -19,13 +25,23 @@ export interface Rng {
  * @returns A deterministic random number generator.
  */
 export function createRng(seed: number): Rng {
-  let state = seed >>> 0;
+  return createRngFromState(seed >>> 0);
+}
+
+/**
+ * Re-creates a {@link Rng} from a previously captured internal state.
+ *
+ * @param state - Internal state obtained via {@link Rng.getState}.
+ */
+export function createRngFromState(state: number): Rng {
+  let internalState = state >>> 0;
   return {
     next: (): number => {
-      state = (state + 0x6d2b79f5) | 0;
-      let t = Math.imul(state ^ (state >>> 15), 1 | state);
+      internalState = (internalState + 0x6d2b79f5) | 0;
+      let t = Math.imul(internalState ^ (internalState >>> 15), 1 | internalState);
       t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
       return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
     },
+    getState: (): number => internalState,
   };
 }

--- a/packages/sim/src/run-scenario.ts
+++ b/packages/sim/src/run-scenario.ts
@@ -1,0 +1,39 @@
+import type { SimulationSnapshot } from './snapshot';
+import { Simulation } from './simulation';
+
+interface ScenarioState {
+  position: number;
+  random: number;
+}
+
+/**
+ * Runs a deterministic scenario used in tests. Each input value represents a
+ * positional delta applied on the corresponding tick.
+ *
+ * @param seed - Seed for the pseudo-random number generator.
+ * @param inputs - List of positional deltas applied sequentially.
+ * @returns Snapshots after each processed tick.
+ */
+export function runScenario(
+  seed: number,
+  inputs: readonly number[],
+): SimulationSnapshot<ScenarioState>[] {
+  let currentInput = 0;
+  const sim = new Simulation<ScenarioState>({
+    timestepMs: 50,
+    seed,
+    initialState: { position: 0, random: 0 },
+    update: (state, rng) => {
+      state.position += currentInput;
+      state.random += rng.next();
+    },
+  });
+
+  const snapshots: SimulationSnapshot<ScenarioState>[] = [];
+  for (const input of inputs) {
+    currentInput = input;
+    sim.advance();
+    snapshots.push(sim.snapshot());
+  }
+  return snapshots;
+}

--- a/packages/sim/src/snapshot.ts
+++ b/packages/sim/src/snapshot.ts
@@ -1,0 +1,13 @@
+export interface SimulationSnapshot<State> {
+  readonly tick: number;
+  readonly rngState: number;
+  readonly state: State;
+}
+
+export function serializeSnapshot<State>(snapshot: SimulationSnapshot<State>): string {
+  return JSON.stringify(snapshot);
+}
+
+export function deserializeSnapshot<State>(json: string): SimulationSnapshot<State> {
+  return JSON.parse(json) as SimulationSnapshot<State>;
+}

--- a/packages/sim/test/data/scenario.golden.json
+++ b/packages/sim/test/data/scenario.golden.json
@@ -1,0 +1,34 @@
+[
+  {
+    "tick": 1,
+    "rngState": 1831565936,
+    "state": {
+      "position": 1,
+      "random": 0.7872516233474016
+    }
+  },
+  {
+    "tick": 2,
+    "rngState": -631835547,
+    "state": {
+      "position": 1,
+      "random": 0.9657951889093965
+    }
+  },
+  {
+    "tick": 3,
+    "rngState": 1199730266,
+    "state": {
+      "position": 0,
+      "random": 1.4611107029486448
+    }
+  },
+  {
+    "tick": 4,
+    "rngState": -1263671217,
+    "state": {
+      "position": 2,
+      "random": 1.6924726655706763
+    }
+  }
+]

--- a/packages/sim/test/simulation.test.ts
+++ b/packages/sim/test/simulation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Simulation } from '../src';
+import { Simulation, deserializeSimulation, runScenario, serializeSnapshot } from '../src';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 describe('Simulation', () => {
   it('produces identical state for identical seeds', () => {
@@ -43,5 +46,36 @@ describe('Simulation', () => {
     vi.advanceTimersByTime(50);
 
     expect(sim.tick).toBe(ticksAfterStop);
+  });
+
+  it('serializes and restores snapshot', () => {
+    const update = (state: { value: number }, rng: { next: () => number }): void => {
+      state.value += rng.next();
+    };
+    const sim = new Simulation<{ value: number }>({
+      timestepMs: 50,
+      seed: 1,
+      initialState: { value: 0 },
+      update,
+    });
+    sim.advance(3);
+    const json = serializeSnapshot(sim.snapshot());
+    const restored = deserializeSimulation<{ value: number }>(json, {
+      timestepMs: 50,
+      update,
+    });
+    restored.advance(2);
+    sim.advance(2);
+    expect(restored.currentState).toEqual(sim.currentState);
+    expect(restored.tick).toBe(sim.tick);
+  });
+
+  it('runScenario matches golden snapshots', () => {
+    const snapshots = runScenario(123, [1, 0, -1, 2]);
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const golden = JSON.parse(
+      readFileSync(join(dir, 'data', 'scenario.golden.json'), 'utf8'),
+    );
+    expect(snapshots).toEqual(golden);
   });
 });


### PR DESCRIPTION
## Summary
- add seedable RNG with exportable state
- implement fixed-timestep simulation with accumulator and snapshot support
- provide `runScenario` helper and golden snapshot tests

## Testing
- `pnpm -F @aife/sim typecheck`
- `pnpm vitest run packages/sim/test/simulation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5f0df5c832aa1839decf4d4cbb1