### PR TITLE
feat(three): add playable three.js viewport

### DIFF
--- a/app/features/three/ThreeViewport.vue
+++ b/app/features/three/ThreeViewport.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { ThreeApp } from './threeApp'
+import { onMounted, onUnmounted, ref } from 'vue'
+import { createThreeApp } from './threeApp'
+
+const container = ref<HTMLDivElement | null>(null)
+const canvas = ref<HTMLCanvasElement | null>(null)
+let app: ThreeApp | null = null
+
+onMounted(() => {
+  if (canvas.value && container.value)
+    app = createThreeApp(canvas.value, container.value)
+})
+
+onUnmounted(() => {
+  app?.dispose()
+  app = null
+})
+</script>
+
+<template>
+  <div ref="container" class="w-full h-full relative">
+    <canvas ref="canvas" class="block w-full h-full" />
+  </div>
+</template>

--- a/app/features/three/entities/Ground.ts
+++ b/app/features/three/entities/Ground.ts
@@ -1,0 +1,22 @@
+import * as THREE from 'three'
+
+/**
+ * Creates the ground mesh and optional grid helper.
+ * The ground is a large plane that receives shadows.
+ */
+export function createGround(size = 100): THREE.Group {
+  const planeGeometry = new THREE.PlaneGeometry(size, size)
+  const planeMaterial = new THREE.MeshStandardMaterial({ color: 0x808080 })
+  const plane = new THREE.Mesh(planeGeometry, planeMaterial)
+  plane.rotation.x = -Math.PI / 2
+  plane.receiveShadow = true
+
+  const grid = new THREE.GridHelper(size, size / 2, 0x000000, 0x000000)
+  grid.material.transparent = true
+  ;(grid.material as THREE.Material).opacity = 0.2
+
+  const group = new THREE.Group()
+  group.add(plane)
+  group.add(grid)
+  return group
+}

--- a/app/features/three/entities/Lights.ts
+++ b/app/features/three/entities/Lights.ts
@@ -1,0 +1,26 @@
+import * as THREE from 'three'
+
+export interface Lights {
+  ambient: THREE.AmbientLight
+  directional: THREE.DirectionalLight
+}
+
+/**
+ * Creates ambient and directional lights with shadows enabled.
+ */
+export function createLights(): Lights {
+  const ambient = new THREE.AmbientLight(0xFFFFFF, 0.4)
+
+  const directional = new THREE.DirectionalLight(0xFFFFFF, 0.8)
+  directional.position.set(5, 10, 5)
+  directional.castShadow = true
+  directional.shadow.mapSize.set(1024, 1024)
+  directional.shadow.camera.near = 1
+  directional.shadow.camera.far = 50
+  directional.shadow.camera.left = -20
+  directional.shadow.camera.right = 20
+  directional.shadow.camera.top = 20
+  directional.shadow.camera.bottom = -20
+
+  return { ambient, directional }
+}

--- a/app/features/three/entities/Player.ts
+++ b/app/features/three/entities/Player.ts
@@ -9,7 +9,7 @@ export interface PlayerState {
 
 export function createPlayer(): PlayerState {
   const geometry = new THREE.BoxGeometry(0.8, 0.2, 1.2)
-  const material = new THREE.MeshStandardMaterial({ color: 0x3b82f6 })
+  const material = new THREE.MeshStandardMaterial({ color: 0x3B82F6 })
   const mesh = new THREE.Mesh(geometry, material)
   mesh.position.set(0, 0.1, 0)
   mesh.castShadow = true
@@ -21,4 +21,3 @@ export function createPlayer(): PlayerState {
     epsilon: 0.03,
   }
 }
-

--- a/app/features/three/input/MouseInput.ts
+++ b/app/features/three/input/MouseInput.ts
@@ -1,0 +1,64 @@
+import type { PlayerState } from '../entities/Player'
+import * as THREE from 'three'
+import { raycastGround } from '../utils/raycastGround'
+
+/**
+ * Handles mouse inputs for right-click movement on the ground.
+ */
+export class MouseInput {
+  private readonly dom: HTMLElement
+  private readonly camera: THREE.Camera
+  private readonly player: PlayerState
+  private readonly marker: THREE.Mesh
+
+  constructor(dom: HTMLElement, camera: THREE.Camera, player: PlayerState, scene: THREE.Scene) {
+    this.dom = dom
+    this.camera = camera
+    this.player = player
+
+    this.marker = new THREE.Mesh(
+      new THREE.RingGeometry(0.25, 0.3, 32),
+      new THREE.MeshBasicMaterial({ color: 0xFFFFFF, transparent: true, opacity: 0.8 }),
+    )
+    this.marker.rotation.x = -Math.PI / 2
+    this.marker.visible = false
+    scene.add(this.marker)
+
+    this.onContextMenu = this.onContextMenu.bind(this)
+    this.onPointerDown = this.onPointerDown.bind(this)
+
+    this.dom.addEventListener('contextmenu', this.onContextMenu)
+    this.dom.addEventListener('pointerdown', this.onPointerDown)
+  }
+
+  private onContextMenu(event: Event) {
+    event.preventDefault()
+  }
+
+  private onPointerDown(event: PointerEvent) {
+    if (event.button !== 2)
+      return
+
+    const rect = this.dom.getBoundingClientRect()
+    const ndc = new THREE.Vector2(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+    )
+    const point = raycastGround(ndc, this.camera)
+    if (point) {
+      this.player.target = point
+      this.marker.position.copy(point)
+      this.marker.visible = true
+    }
+  }
+
+  update(_dt: number): void {
+    // Placeholder for marker animation
+  }
+
+  dispose(): void {
+    this.dom.removeEventListener('contextmenu', this.onContextMenu)
+    this.dom.removeEventListener('pointerdown', this.onPointerDown)
+    this.marker.parent?.remove(this.marker)
+  }
+}

--- a/app/features/three/systems/CameraFollowSystem.ts
+++ b/app/features/three/systems/CameraFollowSystem.ts
@@ -1,0 +1,18 @@
+import * as THREE from 'three'
+
+/**
+ * Smoothly follows the target by interpolating the camera position
+ * towards the desired offset from the target.
+ */
+export function updateCameraFollow(
+  camera: THREE.Camera,
+  target: THREE.Object3D,
+  dt: number,
+  offset = new THREE.Vector3(0, 10, 10),
+  smooth = 5,
+): void {
+  const desired = new THREE.Vector3().copy(target.position).add(offset)
+  const lerpAlpha = 1 - Math.exp(-smooth * dt)
+  camera.position.lerp(desired, lerpAlpha)
+  camera.lookAt(target.position)
+}

--- a/app/features/three/systems/MovementSystem.ts
+++ b/app/features/three/systems/MovementSystem.ts
@@ -1,0 +1,31 @@
+import type { PlayerState } from '../entities/Player'
+import * as THREE from 'three'
+
+/**
+ * Advances the player towards its target at constant speed.
+ * Stops when within `epsilon` distance from the target.
+ */
+export function updateMovement(player: PlayerState, dt: number): void {
+  if (!player.target)
+    return
+
+  const position = player.mesh.position
+  const toTarget = new THREE.Vector3().subVectors(player.target, position)
+  const distance = toTarget.length()
+
+  if (distance <= player.epsilon) {
+    position.copy(player.target)
+    player.target = null
+    return
+  }
+
+  const step = player.speed * dt
+  if (step >= distance) {
+    position.copy(player.target)
+    player.target = null
+    return
+  }
+
+  toTarget.normalize().multiplyScalar(step)
+  position.add(toTarget)
+}

--- a/app/features/three/threeApp.ts
+++ b/app/features/three/threeApp.ts
@@ -1,0 +1,81 @@
+import type { PlayerState } from './entities/Player'
+import * as THREE from 'three'
+import { createGround } from './entities/Ground'
+import { createLights } from './entities/Lights'
+import { createPlayer } from './entities/Player'
+import { MouseInput } from './input/MouseInput'
+import { updateCameraFollow } from './systems/CameraFollowSystem'
+import { updateMovement } from './systems/MovementSystem'
+
+export interface ThreeApp {
+  scene: THREE.Scene
+  camera: THREE.PerspectiveCamera
+  renderer: THREE.WebGLRenderer
+  player: PlayerState
+  dispose: () => void
+}
+
+/**
+ * Creates and starts the Three.js application bound to the provided canvas.
+ */
+export function createThreeApp(canvas: HTMLCanvasElement, container: HTMLElement): ThreeApp {
+  const scene = new THREE.Scene()
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+  renderer.shadowMap.enabled = true
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100)
+  const clock = new THREE.Clock()
+
+  const player = createPlayer()
+  scene.add(player.mesh)
+
+  const ground = createGround()
+  scene.add(ground)
+
+  const lights = createLights()
+  scene.add(lights.ambient)
+  scene.add(lights.directional)
+
+  const mouse = new MouseInput(canvas, camera, player, scene)
+
+  const cameraOffset = new THREE.Vector3(0, 10, 10)
+  camera.position.copy(cameraOffset)
+  camera.lookAt(player.mesh.position)
+
+  let raf = 0
+
+  function onResize() {
+    const width = container.clientWidth
+    const height = container.clientHeight
+    renderer.setSize(width, height)
+    camera.aspect = width / height
+    camera.updateProjectionMatrix()
+  }
+
+  function tick() {
+    const dt = clock.getDelta()
+    updateMovement(player, dt)
+    updateCameraFollow(camera, player.mesh, dt, cameraOffset)
+    mouse.update(dt)
+    renderer.render(scene, camera)
+    raf = requestAnimationFrame(tick)
+  }
+
+  onResize()
+  window.addEventListener('resize', onResize)
+  raf = requestAnimationFrame(tick)
+
+  return {
+    scene,
+    camera,
+    renderer,
+    player,
+    dispose() {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', onResize)
+      mouse.dispose()
+      renderer.dispose()
+    },
+  }
+}

--- a/app/features/three/utils/raycastGround.ts
+++ b/app/features/three/utils/raycastGround.ts
@@ -1,0 +1,22 @@
+import * as THREE from 'three'
+
+/**
+ * Computes the intersection point on the ground (y = `groundY`) from
+ * normalized device coordinates.
+ *
+ * @param ndc - Pointer position in normalized device coordinates.
+ * @param camera - Active camera.
+ * @param groundY - Y position of the ground plane.
+ */
+export function raycastGround(
+  ndc: THREE.Vector2,
+  camera: THREE.Camera,
+  groundY = 0,
+): THREE.Vector3 | null {
+  const raycaster = new THREE.Raycaster()
+  raycaster.setFromCamera(ndc, camera)
+  const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -groundY)
+  const point = new THREE.Vector3()
+  const hit = raycaster.ray.intersectPlane(plane, point)
+  return hit ? point : null
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import ThreeViewport from '~/features/three/ThreeViewport.vue'
+
 definePageMeta({
   layout: 'home',
 })
@@ -28,5 +30,8 @@ const online = useOnline()
       </template>
     </ClientOnly>
     <InputEntry />
+    <ClientOnly>
+      <ThreeViewport class="mt-8 h-80 w-full" />
+    </ClientOnly>
   </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "lint": "eslint .",
     "typecheck": "nuxt typecheck"
   },
+  "dependencies": {
+    "@types/three": "catalog:dev",
+    "taze": "catalog:build",
+    "three": "catalog:frontend"
+  },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev",
     "@iconify-json/carbon": "catalog:icons",
@@ -42,10 +47,5 @@
     "nuxt": "catalog:build",
     "unplugin": "catalog:build",
     "vite": "catalog:build"
-  },
-  "dependencies": {
-    "@types/three": "catalog:dev",
-    "taze": "catalog:build",
-    "three": "catalog:frontend"
   }
 }

--- a/test/MovementSystem.test.ts
+++ b/test/MovementSystem.test.ts
@@ -1,0 +1,24 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import * as THREE from 'three'
+import { createPlayer } from '../app/features/three/entities/Player'
+import { updateMovement } from '../app/features/three/systems/MovementSystem'
+
+const EPSILON = 0.000001
+
+test('moves towards target at expected speed', () => {
+  const player = createPlayer()
+  player.target = new THREE.Vector3(6, 0.1, 0)
+  updateMovement(player, 1)
+  assert.ok(player.target === null)
+  assert.ok(Math.abs(player.mesh.position.x - 6) < EPSILON)
+})
+
+test('does not overshoot target', () => {
+  const player = createPlayer()
+  player.target = new THREE.Vector3(2, 0.1, 0)
+  updateMovement(player, 1)
+  assert.ok(player.target === null)
+  assert.ok(Math.abs(player.mesh.position.x - 2) < EPSILON)
+})

--- a/test/raycastGround.test.ts
+++ b/test/raycastGround.test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import * as THREE from 'three'
+import { raycastGround } from '../app/features/three/utils/raycastGround'
+
+const EPSILON = 0.000001
+
+test('center screen projects to origin on ground', () => {
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100)
+  camera.position.set(0, 10, 10)
+  camera.lookAt(0, 0, 0)
+  const ndc = new THREE.Vector2(0, 0)
+  const point = raycastGround(ndc, camera)
+  assert.ok(point)
+  assert.ok(point!.distanceTo(new THREE.Vector3(0, 0, 0)) < EPSILON)
+})


### PR DESCRIPTION
## Summary
- bootstrap a basic Three.js scene with player, ground, lights, and camera follow
- add movement, camera systems, and mouse-based right-click navigation
- expose the scene via a `ThreeViewport` component and mount it on the home page

## Testing
- `pnpm exec eslint app/features/three test` *(passes with warnings)*
- `pnpm typecheck`
- `pnpm exec tsc test/MovementSystem.test.ts test/raycastGround.test.ts app/features/three/entities/Player.ts app/features/three/systems/MovementSystem.ts app/features/three/utils/raycastGround.ts --module ES2022 --moduleResolution node --target ES2022 --types node --outDir .tmp-tests && node --test .tmp-tests/test/*.test.js` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1636af8f0832abec86aae993a7726