### PR TITLE
feat: add ability cast input workflow

### DIFF
--- a/app/features/three/engine/input/InputMap.ts
+++ b/app/features/three/engine/input/InputMap.ts
@@ -1,5 +1,7 @@
+import type { Ability, AbilityContext } from '../abilities/AbilityBase'
 import type { Hero } from '../hero/Hero'
 import * as THREE from 'three'
+import { raycastGround } from '../../utils/raycastGround'
 import { CastMode } from '../abilities/AbilityBase'
 
 export interface InputBindings {
@@ -17,27 +19,55 @@ const defaultBindings: InputBindings = {
 }
 
 /**
- * Listens to keyboard inputs and triggers ability casts on the hero.
+ * Runtime dependencies required by {@link InputMap}.
+ */
+export interface InputDependencies {
+  /** DOM element receiving pointer events. */
+  element: HTMLElement
+  /** Camera used to compute world coordinates from the pointer. */
+  camera: THREE.Camera
+  /** Object representing the hero for origin coordinates. */
+  origin: THREE.Object3D
+}
+
+/**
+ * Listens to keyboard inputs and mouse clicks to trigger ability casts on the hero.
  */
 export class InputMap {
   public castMode: CastMode = CastMode.Smart
-  private bindings: InputBindings
-  private readonly hero: Hero
 
-  constructor(hero: Hero, bindings: Partial<InputBindings> = {}) {
+  private readonly bindings: InputBindings
+  private readonly hero: Hero
+  private readonly deps: InputDependencies
+
+  private readonly pointer = new THREE.Vector2()
+  private activeAbility: Ability | null = null
+
+  constructor(hero: Hero, deps: InputDependencies, bindings: Partial<InputBindings> = {}) {
     this.hero = hero
+    this.deps = deps
     this.bindings = { ...defaultBindings, ...bindings }
+
     this.onKeyDown = this.onKeyDown.bind(this)
     this.onKeyUp = this.onKeyUp.bind(this)
+    this.onPointerMove = this.onPointerMove.bind(this)
+    this.onPointerDown = this.onPointerDown.bind(this)
+    this.onContextMenu = this.onContextMenu.bind(this)
+
     window.addEventListener('keydown', this.onKeyDown)
     window.addEventListener('keyup', this.onKeyUp)
+    this.deps.element.addEventListener('pointermove', this.onPointerMove)
   }
 
+  /** Detaches all listeners. */
   dispose(): void {
     window.removeEventListener('keydown', this.onKeyDown)
     window.removeEventListener('keyup', this.onKeyUp)
+    this.deps.element.removeEventListener('pointermove', this.onPointerMove)
+    this.detachMouseListeners()
   }
 
+  /** Handles key presses to start ability previews. */
   private onKeyDown(event: KeyboardEvent): void {
     const slot = this.keyToSlot(event.key.toLowerCase())
     if (!slot)
@@ -45,12 +75,18 @@ export class InputMap {
     const ability = this.hero.getAbility(slot)
     if (!ability)
       return
-    if (ability.mode === CastMode.Quick || this.castMode === CastMode.Quick)
-      ability.onPreview({ origin: new THREE.Vector3(), target: new THREE.Vector3() })
-    else
-      ability.onCommit({ origin: new THREE.Vector3(), target: new THREE.Vector3() })
+
+    const mode = ability.mode === CastMode.Smart ? this.castMode : ability.mode
+    const context = this.buildContext()
+    ability.onPreview(context)
+
+    if (mode === CastMode.Normal) {
+      this.activeAbility = ability
+      this.attachMouseListeners()
+    }
   }
 
+  /** Handles key releases to commit quick-cast abilities. */
   private onKeyUp(event: KeyboardEvent): void {
     const slot = this.keyToSlot(event.key.toLowerCase())
     if (!slot)
@@ -58,10 +94,76 @@ export class InputMap {
     const ability = this.hero.getAbility(slot)
     if (!ability)
       return
-    if (ability.mode === CastMode.Quick || this.castMode === CastMode.Quick)
-      ability.onCommit({ origin: new THREE.Vector3(), target: new THREE.Vector3() })
+
+    const mode = ability.mode === CastMode.Smart ? this.castMode : ability.mode
+    if (mode !== CastMode.Quick)
+      return
+
+    const context = this.buildContext()
+    if (this.isWithinRange(ability, context))
+      ability.onCommit(context)
+    else
+      ability.onCancel()
   }
 
+  /** Tracks mouse position for ability targeting. */
+  private onPointerMove(event: PointerEvent): void {
+    const rect = this.deps.element.getBoundingClientRect()
+    this.pointer.set(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+    )
+  }
+
+  /** Commits or cancels an active ability based on mouse input. */
+  private onPointerDown(event: PointerEvent): void {
+    if (!this.activeAbility)
+      return
+
+    if (event.button === 2) {
+      this.activeAbility.onCancel()
+    }
+    else if (event.button === 0) {
+      this.onPointerMove(event)
+      const context = this.buildContext()
+      if (this.isWithinRange(this.activeAbility, context))
+        this.activeAbility.onCommit(context)
+      else
+        this.activeAbility.onCancel()
+    }
+
+    this.activeAbility = null
+    this.detachMouseListeners()
+  }
+
+  /** Prevents the context menu on right click during casting. */
+  private onContextMenu(event: Event): void {
+    event.preventDefault()
+  }
+
+  /** Builds the ability context from the current hero and mouse position. */
+  private buildContext(): AbilityContext {
+    const origin = this.deps.origin.position.clone()
+    const target = raycastGround(this.pointer, this.deps.camera) ?? origin.clone()
+    return { origin, target }
+  }
+
+  /** Checks whether the target is within the ability's range. */
+  private isWithinRange(ability: Ability, context: AbilityContext): boolean {
+    return context.origin.distanceTo(context.target) <= ability.range
+  }
+
+  private attachMouseListeners(): void {
+    this.deps.element.addEventListener('pointerdown', this.onPointerDown)
+    this.deps.element.addEventListener('contextmenu', this.onContextMenu)
+  }
+
+  private detachMouseListeners(): void {
+    this.deps.element.removeEventListener('pointerdown', this.onPointerDown)
+    this.deps.element.removeEventListener('contextmenu', this.onContextMenu)
+  }
+
+  /** Maps a keyboard key to an ability slot. */
   private keyToSlot(key: string): keyof InputBindings | null {
     const entries = Object.entries(this.bindings) as [keyof InputBindings, string][]
     const found = entries.find(([, k]) => k === key)

--- a/app/features/three/threeApp.ts
+++ b/app/features/three/threeApp.ts
@@ -56,7 +56,7 @@ export function createThreeApp(canvas: HTMLCanvasElement, container: HTMLElement
     ultimate: null,
   })
 
-  const input = new InputMap(hero)
+  const input = new InputMap(hero, { element: canvas, camera, origin: player.mesh })
   const casting = new CastingSystem(hero)
 
   const ground = createGround()

--- a/test/InputMap.test.ts
+++ b/test/InputMap.test.ts
@@ -1,14 +1,30 @@
 /* eslint-disable test/no-import-node-test */
+import type { AbilityContext } from '../app/features/three/engine/abilities/AbilityBase'
+import type { InputDependencies } from '../app/features/three/engine/input/InputMap'
 import * as assert from 'node:assert/strict'
 import test from 'node:test'
+import * as THREE from 'three'
 import { AbilityBase, AbilityState, CastMode } from '../app/features/three/engine/abilities/AbilityBase'
 import { Hero } from '../app/features/three/engine/hero/Hero'
 import { InputMap } from '../app/features/three/engine/input/InputMap'
 
 class DummyAbility extends AbilityBase {
-  constructor() {
-    super('dummy', 'Dummy', 0, 0)
-    this.mode = CastMode.Quick
+  previewContext: AbilityContext | null = null
+  commitContext: AbilityContext | null = null
+
+  constructor(mode: CastMode, range: number) {
+    super('dummy', 'Dummy', 0, range)
+    this.mode = mode
+  }
+
+  override onPreview(ctx: AbilityContext): void {
+    super.onPreview(ctx)
+    this.previewContext = ctx
+  }
+
+  override onCommit(ctx: AbilityContext): void {
+    super.onCommit(ctx)
+    this.commitContext = ctx
   }
 }
 
@@ -18,17 +34,77 @@ class KeyEvent extends Event {
   }
 }
 
+class PointerEvt extends Event {
+  constructor(type: string, public clientX: number, public clientY: number, public button: number) {
+    super(type)
+  }
+}
+
+class StubElement extends EventTarget {
+  getBoundingClientRect() {
+    return { left: 0, top: 0, width: 100, height: 100 } as DOMRect
+  }
+}
+
+function createDeps(origin: THREE.Object3D): InputDependencies {
+  const element = new StubElement() as unknown as HTMLElement
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100)
+  camera.position.set(0, 10, 10)
+  camera.lookAt(0, 0, 0)
+  return { element, camera, origin }
+}
+
 test('quick cast preview and commit', () => {
   ;(globalThis as any).window = new EventTarget()
-  const ability = new DummyAbility()
+  const origin = new THREE.Object3D()
+  const deps = createDeps(origin)
+  const ability = new DummyAbility(CastMode.Quick, 5)
   const hero = new Hero({ primary: ability, secondary: null, tertiary: null, ultimate: null })
-  const input = new InputMap(hero)
-  input.castMode = CastMode.Quick
+  const input = new InputMap(hero, deps)
 
+  deps.element.dispatchEvent(new PointerEvt('pointermove', 50, 50, 0))
   window.dispatchEvent(new KeyEvent('keydown', 'a'))
   assert.equal(ability.state, AbilityState.Preview)
   window.dispatchEvent(new KeyEvent('keyup', 'a'))
   assert.equal(ability.state, AbilityState.Casting)
+  assert.notEqual(ability.commitContext, null)
+
+  input.dispose()
+})
+
+test('normal cast commit and cancel', () => {
+  ;(globalThis as any).window = new EventTarget()
+  const origin = new THREE.Object3D()
+  const deps = createDeps(origin)
+  const ability = new DummyAbility(CastMode.Smart, 5)
+  const hero = new Hero({ primary: ability, secondary: null, tertiary: null, ultimate: null })
+  const input = new InputMap(hero, deps)
+  input.castMode = CastMode.Normal
+
+  window.dispatchEvent(new KeyEvent('keydown', 'a'))
+  deps.element.dispatchEvent(new PointerEvt('pointerdown', 50, 50, 0))
+  assert.equal(ability.state, AbilityState.Casting)
+
+  ability.state = AbilityState.Idle
+  window.dispatchEvent(new KeyEvent('keydown', 'a'))
+  deps.element.dispatchEvent(new PointerEvt('pointerdown', 50, 50, 2))
+  assert.equal(ability.state, AbilityState.Idle)
+
+  input.dispose()
+})
+
+test('normal cast cancels when out of range', () => {
+  ;(globalThis as any).window = new EventTarget()
+  const origin = new THREE.Object3D()
+  const deps = createDeps(origin)
+  const ability = new DummyAbility(CastMode.Smart, 0.5)
+  const hero = new Hero({ primary: ability, secondary: null, tertiary: null, ultimate: null })
+  const input = new InputMap(hero, deps)
+  input.castMode = CastMode.Normal
+
+  window.dispatchEvent(new KeyEvent('keydown', 'a'))
+  deps.element.dispatchEvent(new PointerEvt('pointerdown', 100, 0, 0))
+  assert.equal(ability.state, AbilityState.Idle)
 
   input.dispose()
 })


### PR DESCRIPTION
## Summary
- handle preview/commit/cancel for ability casting with keyboard and mouse
- add range validation and right-click cancellation
- cover quick and normal cast modes with tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `node --loader ts-node/esm --test test/InputMap.test.ts` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68b17c9f8a44832a8ce122b8cda9427e