### PR TITLE
feat: implement ability cooldown and recovery handling

### DIFF
--- a/app/features/three/engine/abilities/AbilityBase.ts
+++ b/app/features/three/engine/abilities/AbilityBase.ts
@@ -36,9 +36,14 @@ export interface Ability {
   readonly id: string
   readonly name: string
   readonly cooldown: number
+  /** Duration spent recovering after the effect resolves. */
+  readonly recovery: number
   readonly range: number
   state: AbilityState
   mode: CastMode
+
+  /** Seconds remaining before the ability can be used again. */
+  cooldownRemaining: number
 
   /** Called when the player requests a preview. */
   onPreview: (context: AbilityContext) => void
@@ -56,27 +61,43 @@ export interface Ability {
 export abstract class AbilityBase implements Ability {
   public state: AbilityState = AbilityState.Idle
   public mode: CastMode = CastMode.Smart
+  public cooldownRemaining = 0
+  private recoveryRemaining = 0
 
   constructor(
     public readonly id: string,
     public readonly name: string,
     public readonly cooldown: number,
     public readonly range: number,
+    public readonly recovery: number,
   ) {}
 
   onPreview(_context: AbilityContext): void {
+    if (this.cooldownRemaining > 0 || this.state !== AbilityState.Idle)
+      return
     this.state = AbilityState.Preview
   }
 
   onCommit(_context: AbilityContext): void {
+    if (this.cooldownRemaining > 0)
+      return
     this.state = AbilityState.Casting
+    this.cooldownRemaining = this.cooldown
+    this.recoveryRemaining = this.recovery
   }
 
   onCancel(): void {
     this.state = AbilityState.Idle
   }
 
-  onUpdate(_dt: number): void {
-    // Default no-op
+  onUpdate(dt: number): void {
+    if (this.cooldownRemaining > 0)
+      this.cooldownRemaining = Math.max(0, this.cooldownRemaining - dt)
+
+    if (this.state === AbilityState.Recovery) {
+      this.recoveryRemaining -= dt
+      if (this.recoveryRemaining <= 0)
+        this.state = AbilityState.Idle
+    }
   }
 }

--- a/app/features/three/engine/abilities/impl/CircleAoeAbility.ts
+++ b/app/features/three/engine/abilities/impl/CircleAoeAbility.ts
@@ -8,6 +8,7 @@ export interface CircleAoeConfig {
   range: number
   delay: number
   damage: number
+  recovery: number
 }
 
 /**
@@ -19,11 +20,13 @@ export class CircleAoeAbility extends AbilityBase {
     private readonly damageSystem: DamageSystem,
     private readonly config: CircleAoeConfig,
   ) {
-    super('circle-aoe', 'Circle AOE', 6, config.range)
+    super('circle-aoe', 'Circle AOE', 6, config.range, config.recovery)
   }
 
   override onCommit(context: AbilityContext): void {
     super.onCommit(context)
+    if (this.state !== AbilityState.Casting)
+      return
     setTimeout(() => {
       const entities = this.collision.queryCircle(context.target, this.config.radius)
       entities.forEach(e => e.health && this.damageSystem.damage(e.health, this.config.damage))

--- a/app/features/three/engine/abilities/impl/DashAbility.ts
+++ b/app/features/three/engine/abilities/impl/DashAbility.ts
@@ -5,6 +5,7 @@ import { AbilityBase, AbilityState } from '../AbilityBase'
 
 export interface DashConfig {
   distance: number
+  recovery: number
 }
 
 /**
@@ -12,11 +13,13 @@ export interface DashConfig {
  */
 export class DashAbility extends AbilityBase {
   constructor(private readonly caster: THREE.Object3D, private readonly config: DashConfig) {
-    super('dash', 'Dash', 3, config.distance)
+    super('dash', 'Dash', 3, config.distance, config.recovery)
   }
 
   override onCommit(context: AbilityContext): void {
     super.onCommit(context)
+    if (this.state !== AbilityState.Casting)
+      return
     dash(this.caster, this.config.distance)
     this.state = AbilityState.Recovery
   }

--- a/app/features/three/engine/abilities/impl/RectPushAbility.ts
+++ b/app/features/three/engine/abilities/impl/RectPushAbility.ts
@@ -10,6 +10,7 @@ export interface RectPushConfig {
   damage: number
   knockbackNear: number
   knockbackFar: number
+  recovery: number
 }
 
 /**
@@ -22,11 +23,13 @@ export class RectPushAbility extends AbilityBase {
     private readonly damageSystem: DamageSystem,
     private readonly config: RectPushConfig,
   ) {
-    super('rect-push', 'Rect Push', 4, config.length)
+    super('rect-push', 'Rect Push', 4, config.length, config.recovery)
   }
 
   override onCommit(context: AbilityContext): void {
     super.onCommit(context)
+    if (this.state !== AbilityState.Casting)
+      return
     const forward = new THREE.Vector3().subVectors(context.target, context.origin).normalize()
     const entities = this.collision.queryRectangle(context.origin, forward, this.config.length, this.config.width)
     entities.forEach(e => this.applyEffect(e, context.origin))

--- a/app/features/three/engine/config/balance/abilities.json
+++ b/app/features/three/engine/config/balance/abilities.json
@@ -4,15 +4,18 @@
     "length": 4,
     "damage": 20,
     "knockbackNear": 3,
-    "knockbackFar": 1
+    "knockbackFar": 1,
+    "recovery": 0.5
   },
   "dash": {
-    "distance": 2
+    "distance": 2,
+    "recovery": 0.3
   },
   "circle-aoe": {
     "radius": 2,
     "range": 6,
     "delay": 0.5,
-    "damage": 30
+    "damage": 30,
+    "recovery": 0.7
   }
 }

--- a/app/features/three/engine/input/InputMap.ts
+++ b/app/features/three/engine/input/InputMap.ts
@@ -2,7 +2,7 @@ import type { Ability, AbilityContext } from '../abilities/AbilityBase'
 import type { Hero } from '../hero/Hero'
 import * as THREE from 'three'
 import { raycastGround } from '../../utils/raycastGround'
-import { CastMode } from '../abilities/AbilityBase'
+import { AbilityState, CastMode } from '../abilities/AbilityBase'
 
 export interface InputBindings {
   primary: string
@@ -79,6 +79,8 @@ export class InputMap {
     const mode = ability.mode === CastMode.Smart ? this.castMode : ability.mode
     const context = this.buildContext()
     ability.onPreview(context)
+    if (ability.state !== AbilityState.Preview)
+      return
 
     if (mode === CastMode.Normal) {
       this.activeAbility = ability
@@ -99,6 +101,8 @@ export class InputMap {
     if (mode !== CastMode.Quick)
       return
 
+    if (ability.state !== AbilityState.Preview)
+      return
     const context = this.buildContext()
     if (this.isWithinRange(ability, context))
       ability.onCommit(context)

--- a/app/features/three/engine/systems/CastingSystem.ts
+++ b/app/features/three/engine/systems/CastingSystem.ts
@@ -1,7 +1,8 @@
 import type { Hero } from '../hero/Hero'
+import { AbilityState } from '../abilities/AbilityBase'
 
 /**
- * Updates active abilities every frame.
+ * Updates abilities every frame to handle recovery and cooldown timers.
  */
 export class CastingSystem {
   constructor(private readonly hero: Hero) {}
@@ -9,7 +10,8 @@ export class CastingSystem {
   update(dt: number): void {
     for (const key of Object.keys(this.hero.slots) as (keyof typeof this.hero.slots)[]) {
       const ability = this.hero.getAbility(key)
-      ability?.onUpdate(dt)
+      if (ability && (ability.state !== AbilityState.Idle || ability.cooldownRemaining > 0))
+        ability.onUpdate(dt)
     }
   }
 }

--- a/app/features/three/utils/raycastGround.ts
+++ b/app/features/three/utils/raycastGround.ts
@@ -14,6 +14,7 @@ export function raycastGround(
   groundY = 0,
 ): THREE.Vector3 | null {
   const raycaster = new THREE.Raycaster()
+  camera.updateMatrixWorld()
   raycaster.setFromCamera(ndc, camera)
   const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -groundY)
   const point = new THREE.Vector3()

--- a/test/AbilityCooldown.test.ts
+++ b/test/AbilityCooldown.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import * as THREE from 'three'
+import { AbilityBase, AbilityState } from '../app/features/three/engine/abilities/AbilityBase'
+import { Hero } from '../app/features/three/engine/hero/Hero'
+import { CastingSystem } from '../app/features/three/engine/systems/CastingSystem'
+
+class CooldownAbility extends AbilityBase {
+  constructor(cooldown: number, recovery: number) {
+    super('cooldown', 'Cooldown Ability', cooldown, 1, recovery)
+  }
+
+  override onCommit(context: any): void {
+    super.onCommit(context)
+    if (this.state !== AbilityState.Casting)
+      return
+    this.state = AbilityState.Recovery
+  }
+}
+
+test('ability respects cooldown and recovery', () => {
+  const ability = new CooldownAbility(2, 0.5)
+  const hero = new Hero({ primary: ability, secondary: null, tertiary: null, ultimate: null })
+  const casting = new CastingSystem(hero)
+  const context = { origin: new THREE.Vector3(), target: new THREE.Vector3() }
+
+  ability.onPreview(context)
+  ability.onCommit(context)
+  assert.equal(ability.state, AbilityState.Recovery)
+  assert.ok(ability.cooldownRemaining > 0)
+
+  casting.update(0.25)
+  casting.update(0.25)
+  assert.equal(ability.state, AbilityState.Idle)
+  const remainingAfterRecovery = ability.cooldownRemaining
+  assert.ok(remainingAfterRecovery > 0)
+
+  ability.onPreview(context)
+  assert.equal(ability.state, AbilityState.Idle)
+  ability.onCommit(context)
+  assert.equal(ability.state, AbilityState.Idle)
+  assert.equal(ability.cooldownRemaining, remainingAfterRecovery)
+
+  casting.update(1.5)
+  assert.equal(ability.cooldownRemaining, 0)
+
+  ability.onPreview(context)
+  assert.equal(ability.state, AbilityState.Preview)
+})

--- a/test/InputMap.test.ts
+++ b/test/InputMap.test.ts
@@ -12,8 +12,8 @@ class DummyAbility extends AbilityBase {
   previewContext: AbilityContext | null = null
   commitContext: AbilityContext | null = null
 
-  constructor(mode: CastMode, range: number) {
-    super('dummy', 'Dummy', 0, range)
+  constructor(mode: CastMode, range: number, recovery = 0) {
+    super('dummy', 'Dummy', 0, range, recovery)
     this.mode = mode
   }
 


### PR DESCRIPTION
## Summary
- track remaining cooldown and recovery on abilities
- add recovery durations for dash, rect-push, and circle AOE abilities
- gate input by ability state and tick cooldowns in casting system
- test ability cooldown enforcement

## Testing
- `pnpm dlx tsx --test test/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b182263d20832ab35e597528ac31e3