### PR TITLE
Use dt-based timer for circle AOE

### DIFF
--- a/app/features/three/engine/abilities/impl/CircleAoeAbility.ts
+++ b/app/features/three/engine/abilities/impl/CircleAoeAbility.ts
@@ -2,6 +2,7 @@ import type { CollisionService } from '../../physics/CollisionService'
 import type { DamageSystem } from '../../systems/DamageSystem'
 import type { AbilityContext } from '../AbilityBase'
 import { AbilityBase, AbilityState } from '../AbilityBase'
+import type * as THREE from 'three'
 
 export interface CircleAoeConfig {
   radius: number
@@ -15,6 +16,9 @@ export interface CircleAoeConfig {
  * Area of effect ability damaging units in a circle after a delay.
  */
 export class CircleAoeAbility extends AbilityBase {
+  private delayRemaining = 0
+  private target: THREE.Vector3 | null = null
+
   constructor(
     private readonly collision: CollisionService,
     private readonly damageSystem: DamageSystem,
@@ -27,10 +31,35 @@ export class CircleAoeAbility extends AbilityBase {
     super.onCommit(context)
     if (this.state !== AbilityState.Casting)
       return
-    setTimeout(() => {
-      const entities = this.collision.queryCircle(context.target, this.config.radius)
-      entities.forEach(e => e.health && this.damageSystem.damage(e.health, this.config.damage))
-      this.state = AbilityState.Recovery
-    }, this.config.delay * 1000)
+    this.delayRemaining = this.config.delay
+    this.target = context.target.clone()
+  }
+
+  override onCancel(): void {
+    super.onCancel()
+    this.delayRemaining = 0
+    this.target = null
+  }
+
+  override onUpdate(dt: number): void {
+    super.onUpdate(dt)
+
+    if (this.state !== AbilityState.Casting || !this.target)
+      return
+
+    this.delayRemaining -= dt
+    if (this.delayRemaining > 0)
+      return
+
+    const entities = this.collision.queryCircle(this.target, this.config.radius)
+    entities.forEach(e => e.health && this.damageSystem.damage(e.health, this.config.damage))
+    this.state = AbilityState.Recovery
+    const overflow = -this.delayRemaining
+    this.delayRemaining = 0
+    this.target = null
+    if (overflow > 0) {
+      this.cooldownRemaining += overflow
+      super.onUpdate(overflow)
+    }
   }
 }

--- a/test/CircleAoeAbility.test.ts
+++ b/test/CircleAoeAbility.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import * as THREE from 'three'
+import { CircleAoeAbility } from '../app/features/three/engine/abilities/impl/CircleAoeAbility'
+import { AbilityState } from '../app/features/three/engine/abilities/AbilityBase'
+import config from '../app/features/three/engine/config/balance/abilities.json'
+import { CollisionService } from '../app/features/three/engine/physics/CollisionService'
+import { DamageSystem } from '../app/features/three/engine/systems/DamageSystem'
+
+test('circle aoe triggers after delay then recovers', () => {
+  const origin = new THREE.Vector3()
+  const target = new THREE.Vector3()
+  const enemy = new THREE.Object3D()
+  enemy.position.copy(target)
+  const health = { current: 100, max: 100 }
+  const collision = new CollisionService([{ position: enemy.position, radius: 0.5, object: enemy, health }])
+  const damage = new DamageSystem()
+  const ability = new CircleAoeAbility(collision, damage, config['circle-aoe'])
+
+  ability.onCommit({ origin, target })
+  ability.onUpdate(0.25)
+  assert.equal(damage.events.length, 0)
+  assert.equal(ability.state, AbilityState.Casting)
+
+  ability.onUpdate(0.25)
+  assert.equal(damage.events.length, 1)
+  assert.equal(ability.state, AbilityState.Recovery)
+
+  ability.onUpdate(config['circle-aoe'].recovery)
+  assert.equal(ability.state, AbilityState.Idle)
+})
+
+test('circle aoe cancels before impact', () => {
+  const origin = new THREE.Vector3()
+  const target = new THREE.Vector3()
+  const enemy = new THREE.Object3D()
+  enemy.position.copy(target)
+  const health = { current: 100, max: 100 }
+  const collision = new CollisionService([{ position: enemy.position, radius: 0.5, object: enemy, health }])
+  const damage = new DamageSystem()
+  const ability = new CircleAoeAbility(collision, damage, config['circle-aoe'])
+
+  ability.onCommit({ origin, target })
+  ability.onUpdate(0.25)
+  ability.onCancel()
+  ability.onUpdate(1)
+  assert.equal(damage.events.length, 0)
+  assert.equal(ability.state, AbilityState.Idle)
+})


### PR DESCRIPTION
## Summary
- track circle AOE delay with `onUpdate` instead of `setTimeout`
- cancel pending circle AOE when interrupted before impact
- cover delay and cancellation logic with unit tests

## Testing
- `node --import tsx --test test/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b18c677c38832aba18e3d82924f1ad