### PR TITLE
feat(dash): raycast and clamp dash distance

### DIFF
--- a/app/features/three/engine/abilities/impl/DashAbility.ts
+++ b/app/features/three/engine/abilities/impl/DashAbility.ts
@@ -12,7 +12,12 @@ export interface DashConfig {
  * Simple forward dash of the caster.
  */
 export class DashAbility extends AbilityBase {
-  constructor(private readonly caster: THREE.Object3D, private readonly config: DashConfig) {
+  constructor(
+    private readonly caster: THREE.Object3D,
+    private readonly config: DashConfig,
+    private readonly obstacles: THREE.Object3D[] = [],
+    private readonly slide = false,
+  ) {
     super('dash', 'Dash', 3, config.distance, config.recovery)
   }
 
@@ -20,7 +25,7 @@ export class DashAbility extends AbilityBase {
     super.onCommit(context)
     if (this.state !== AbilityState.Casting)
       return
-    dash(this.caster, this.config.distance)
+    dash(this.caster, this.config.distance, this.obstacles, this.slide)
     this.state = AbilityState.Recovery
   }
 }

--- a/app/features/three/engine/movement/DashSystem.ts
+++ b/app/features/three/engine/movement/DashSystem.ts
@@ -1,10 +1,53 @@
 import * as THREE from 'three'
 
+/** Distance kept from a collision surface to avoid clipping. */
+export const DASH_EPSILON = 0.001
+
 /**
  * Moves an object instantly along its forward vector by the given distance.
+ * The movement is raycast against the provided obstacles and clamped to the
+ * first hit. When `slide` is true the remaining distance is projected on the
+ * hit surface allowing soft collisions.
+ *
+ * @param object - Object to move.
+ * @param distance - Desired travel distance.
+ * @param obstacles - List of collidable objects.
+ * @param slide - Whether to slide along the hit surface instead of stopping.
  */
-export function dash(object: THREE.Object3D, distance: number): void {
+export function dash(
+  object: THREE.Object3D,
+  distance: number,
+  obstacles: THREE.Object3D[] = [],
+  slide = false,
+): void {
   const forward = new THREE.Vector3()
   object.getWorldDirection(forward)
-  object.position.add(forward.multiplyScalar(distance))
+
+  const raycaster = new THREE.Raycaster()
+  raycaster.far = distance
+  raycaster.set(object.position, forward)
+  const hits = raycaster.intersectObjects(obstacles, false)
+
+  if (hits.length > 0) {
+    const hit = hits[0]!
+    const travel = Math.max(0, hit.distance - DASH_EPSILON)
+
+    if (slide && hit.face) {
+      const normal = hit.face.normal
+        .clone()
+        .transformDirection(hit.object.matrixWorld)
+        .normalize()
+      const remaining = distance - hit.distance
+      const slideDir = forward.clone().projectOnPlane(normal).normalize()
+      object.position
+        .addScaledVector(forward, travel)
+        .addScaledVector(slideDir, remaining)
+      return
+    }
+
+    object.position.addScaledVector(forward, travel)
+    return
+  }
+
+  object.position.addScaledVector(forward, distance)
 }

--- a/test/DashAbility.test.ts
+++ b/test/DashAbility.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import * as THREE from 'three'
+import { DashAbility } from '../app/features/three/engine/abilities/impl/DashAbility'
+import { DASH_EPSILON } from '../app/features/three/engine/movement/DashSystem'
+
+test('dash clamps distance to first obstacle', () => {
+  const caster = new THREE.Object3D()
+  caster.rotation.y = Math.PI
+
+  const wall = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1))
+  wall.position.set(0, 0, 2)
+  wall.updateMatrixWorld()
+
+  const ability = new DashAbility(caster, { distance: 5, recovery: 0 }, [wall])
+  ability.onCommit({ origin: new THREE.Vector3(), target: new THREE.Vector3() })
+
+  const maxZ = 2 - 0.5 - DASH_EPSILON
+  assert.ok(Math.abs(caster.position.z - maxZ) < 0.01)
+})
+
+test('dash slides along surfaces when enabled', () => {
+  const caster = new THREE.Object3D()
+  caster.lookAt(new THREE.Vector3(1, 0, 1))
+
+  const wall = new THREE.Mesh(
+    new THREE.PlaneGeometry(5, 5),
+    new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }),
+  )
+  wall.position.set(1, 0, 0)
+  wall.rotation.y = -Math.PI / 2
+  wall.updateMatrixWorld()
+
+  const distance = 3
+  const ability = new DashAbility(caster, { distance, recovery: 0 }, [wall], true)
+  ability.onCommit({ origin: new THREE.Vector3(), target: new THREE.Vector3() })
+
+  const forward = new THREE.Vector3()
+  caster.getWorldDirection(forward)
+  const hitDistance = 1 / forward.x
+  const remaining = distance - hitDistance
+  const expectedX = 1 - DASH_EPSILON * forward.x
+  const expectedZ = forward.z * (hitDistance - DASH_EPSILON) + remaining
+
+  assert.ok(Math.abs(caster.position.x - expectedX) < 0.01)
+  assert.ok(Math.abs(caster.position.z - expectedZ) < 0.01)
+})


### PR DESCRIPTION
## Summary
- raycast dash path and clamp to first collision
- allow optional sliding along surfaces for soft collisions
- cover dash clamping and sliding with unit tests

## Testing
- `npm run lint` *(fails: Expected "three" (type) to come before "../AbilityBase" (parent))*
- `npm run typecheck`
- `node --test test/DashAbility.test.ts` *(fails: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /workspace/didier/test/DashAbility.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b18f30e488832a9122ff3d54a33020