### PR TITLE
feat: track entity death in damage system

### DIFF
--- a/app/features/three/engine/physics/CollisionService.ts
+++ b/app/features/three/engine/physics/CollisionService.ts
@@ -1,10 +1,11 @@
 import * as THREE from 'three'
+import type { HealthComponent } from '../stats/HealthComponent'
 
 export interface CollisionEntity {
   position: THREE.Vector3
   radius: number
   object?: THREE.Object3D
-  health?: { current: number, max: number }
+  health?: HealthComponent
 }
 
 /**

--- a/app/features/three/engine/stats/HealthComponent.ts
+++ b/app/features/three/engine/stats/HealthComponent.ts
@@ -4,4 +4,8 @@
 export interface HealthComponent {
   current: number
   max: number
+  /** Whether the entity has been marked as dead. */
+  isDead: boolean
+  /** Timestamp of death in milliseconds since epoch. */
+  deathTimestamp?: number
 }

--- a/app/features/three/engine/systems/DamageSystem.ts
+++ b/app/features/three/engine/systems/DamageSystem.ts
@@ -1,18 +1,33 @@
 import type { HealthComponent } from '../stats/HealthComponent'
 
 export interface DamageEvent {
+  type: 'damage'
   amount: number
   target: HealthComponent
 }
+
+export interface DeathEvent {
+  type: 'death'
+  target: HealthComponent
+  timestamp: number
+}
+
+export type DamageSystemEvent = DamageEvent | DeathEvent
 
 /**
  * Applies damage to health components and emits events.
  */
 export class DamageSystem {
-  public readonly events: DamageEvent[] = []
+  public readonly events: DamageSystemEvent[] = []
 
   damage(target: HealthComponent, amount: number): void {
     target.current = Math.max(0, target.current - amount)
-    this.events.push({ amount, target })
+    this.events.push({ type: 'damage', amount, target })
+    if (target.current <= 0 && !target.isDead) {
+      target.isDead = true
+      const timestamp = Date.now()
+      target.deathTimestamp = timestamp
+      this.events.push({ type: 'death', target, timestamp })
+    }
   }
 }

--- a/test/CircleAoeAbility.test.ts
+++ b/test/CircleAoeAbility.test.ts
@@ -13,7 +13,7 @@ test('circle aoe triggers after delay then recovers', () => {
   const target = new THREE.Vector3()
   const enemy = new THREE.Object3D()
   enemy.position.copy(target)
-  const health = { current: 100, max: 100 }
+  const health = { current: 100, max: 100, isDead: false }
   const collision = new CollisionService([{ position: enemy.position, radius: 0.5, object: enemy, health }])
   const damage = new DamageSystem()
   const ability = new CircleAoeAbility(collision, damage, config['circle-aoe'])
@@ -36,7 +36,7 @@ test('circle aoe cancels before impact', () => {
   const target = new THREE.Vector3()
   const enemy = new THREE.Object3D()
   enemy.position.copy(target)
-  const health = { current: 100, max: 100 }
+  const health = { current: 100, max: 100, isDead: false }
   const collision = new CollisionService([{ position: enemy.position, radius: 0.5, object: enemy, health }])
   const damage = new DamageSystem()
   const ability = new CircleAoeAbility(collision, damage, config['circle-aoe'])

--- a/test/DamageSystem.test.ts
+++ b/test/DamageSystem.test.ts
@@ -1,0 +1,13 @@
+/* eslint-disable test/no-import-node-test */
+import * as assert from 'node:assert/strict'
+import test from 'node:test'
+import { DamageSystem } from '../app/features/three/engine/systems/DamageSystem'
+
+test('fires death event when health is depleted', () => {
+  const system = new DamageSystem()
+  const health = { current: 0, max: 100, isDead: false }
+  system.damage(health, 0)
+  const deathEvents = system.events.filter(e => e.type === 'death')
+  assert.equal(deathEvents.length, 1)
+  assert.equal(health.isDead, true)
+})


### PR DESCRIPTION
## Summary
- extend `HealthComponent` with `isDead` and optional `deathTimestamp`
- emit `death` events in `DamageSystem`
- cover death event with unit test

## Testing
- `npm run lint` *(fails: Unexpected newline between function and ( of function call, etc.)*
- `npm run typecheck` *(fails: This expression is not callable, Parameter 'slot' implicitly has an 'any' type, Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'KeyBindings')*
- `node --loader ts-node/esm --test test/DamageSystem.test.ts` *(fails: Cannot find package 'ts-node' imported from /workspace/didier)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a1207ef4832ab0dba8308c8ec763