### PR TITLE
feat: toggle player torch with right mouse

### DIFF
--- a/src/3d/input/actions.ts
+++ b/src/3d/input/actions.ts
@@ -23,6 +23,7 @@ export type ActionId =
 	| "game.primary" // legacy alias (kept for compatibility)
 	| "game.secondary" // legacy alias (was RMB)
 	| "game.dash"
+	| "game.toggleTorch"
 	| "game.look" // analog delta (dx, dy)
 	| "game.pause"
 	// Camera controls
@@ -129,6 +130,12 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
 	// Primary spell (A/Q). Use this for Spell #1.
 	"game.spell.1": {
 		id: "game.spell.1",
+		kind: "digital",
+		domain: "game",
+		contexts: ["gameplay"],
+	},
+	"game.toggleTorch": {
+		id: "game.toggleTorch",
 		kind: "digital",
 		domain: "game",
 		contexts: ["gameplay"],

--- a/src/3d/input/bindings.ts
+++ b/src/3d/input/bindings.ts
@@ -23,7 +23,7 @@ export function buildDefaultBindings(layout: KeyboardLayout): ContextBindings {
 		"Key:ShiftLeft": "game.sprint",
 		"Key:ShiftRight": "game.sprint",
 		"Mouse:Left": "game.fire",
-		// Do not bind RMB to a spell; RMB is used for move orders in-scene
+		"Mouse:Right": "game.toggleTorch",
 		"Key:KeyE": "game.dash",
 		// Pause/Menu
 		"Key:Escape": "ui.toggleMenu",


### PR DESCRIPTION
## Summary
- bind right mouse to `game.toggleTorch`
- add torch toggle state and brighter global lighting

## Testing
- `bunx biome check src/3d/input/bindings.ts src/3d/input/actions.ts src/components/3d/Game.tsx`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c68400061c832aa4c71a693033c1eb