### PR TITLE
feat(input): persist keyboard layout detection

### DIFF
--- a/src/3d/input/keyboard-layout.ts
+++ b/src/3d/input/keyboard-layout.ts
@@ -1,41 +1,67 @@
 import type { KeyboardLayout } from "./bindings";
 
+/** Storage key used to persist the detected layout across sessions. */
+const STORAGE_KEY = "didier.keyboardLayout";
+
 /**
- * Detects the user's keyboard layout. Defaults to "qwerty".
- * Uses `navigator.keyboard.getLayoutMap` when available and falls back to
- * language heuristics.
+ * Synchronously detects the user's keyboard layout.
+ *
+ * The function first attempts to read a previously resolved layout from
+ * `localStorage`. If none is found, a heuristic based on the browser's
+ * language is applied. The detection intentionally avoids async APIs so it
+ * can run during React's initial render phase.
  */
 export function detectKeyboardLayout(): KeyboardLayout {
-	if (typeof navigator !== "undefined") {
-		const nav = navigator as Navigator & {
-			keyboard?: { getLayoutMap?: () => Promise<Map<string, string>> };
-		};
-		if (typeof nav.keyboard?.getLayoutMap === "function") {
-			// Attempt synchronous guess using language and fall back to async map.
+	if (typeof window !== "undefined") {
+		try {
+			const stored = window.localStorage.getItem(STORAGE_KEY);
+			if (stored === "azerty" || stored === "qwerty") {
+				return stored;
+			}
+		} catch {
+			// ignore storage errors (e.g., private mode)
 		}
-		const lang = (navigator.language || "").toLowerCase();
-		if (lang.startsWith("fr")) return "azerty";
+
+		const lang = window.navigator.language.toLowerCase();
+		if (lang.startsWith("fr")) {
+			return "azerty";
+		}
 	}
+
 	return "qwerty";
 }
 
 /**
- * Attempts to resolve the layout using the Keyboard API, if supported.
- * This function is asynchronous and should be called after user interaction
- * (some browsers gate the API behind permissions).
+ * Resolves the keyboard layout using the Keyboard Layout Map API when
+ * available. The resolved layout is persisted in `localStorage` so subsequent
+ * synchronous calls to {@link detectKeyboardLayout} can reuse it.
  */
 export async function resolveLayoutAsync(): Promise<KeyboardLayout> {
+	let layout: KeyboardLayout = "qwerty";
+
 	try {
-		const nav = navigator as Navigator & {
+		const nav = window.navigator as Navigator & {
 			keyboard?: { getLayoutMap?: () => Promise<Map<string, string>> };
 		};
 		const map = await nav.keyboard?.getLayoutMap?.();
-		const keyQ = map?.get("KeyQ");
-		if (typeof keyQ === "string" && keyQ.toLowerCase() === "a") {
-			return "azerty";
+
+		const keyQ = map?.get("KeyQ")?.toLowerCase();
+		const keyW = map?.get("KeyW")?.toLowerCase();
+
+		// On azerty keyboards, physical KeyQ produces "a" and KeyW produces "z".
+		if (keyQ === "a" || keyW === "z") {
+			layout = "azerty";
 		}
 	} catch {
-		// ignore and fall back
+		// Swallow errors and fall back to heuristic detection.
+		layout = detectKeyboardLayout();
 	}
-	return detectKeyboardLayout();
+
+	try {
+		window.localStorage.setItem(STORAGE_KEY, layout);
+	} catch {
+		// ignore persistence errors
+	}
+
+	return layout;
 }


### PR DESCRIPTION
## Summary
- cache detected keyboard layout in localStorage
- resolve layout using Keyboard Layout Map API and fall back to language heuristics

## Testing
- `bun x biome check src/3d/input/keyboard-layout.ts`
- `bun run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c69a0a8ecc832aa29304a2124f550e